### PR TITLE
GitHubワークフローファイルの作成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,114 +1,129 @@
-name: CI
+name: Python CI
 
-# ワークフローのトリガーイベントを設定します。
-# workflow_dispatchは手動実行を可能にします。
-# 他のイベントを追加する場合は、以下のように記述します。
-# on:
-#   push:
-#     branches:
-#       - main
-#   pull_request:
-#     branches:
-#       - main
 on:
   workflow_dispatch:
+    # 他のイベントを追加する場合は、以下を参考にしてください。
+    # push:
+    #   branches: [ main, develop ]
+    # pull_request:
+    #   branches: [ main, develop ]
+    # schedule:
+    #   - cron: '0 0 * * *' # 毎日深夜0時に実行
 
 jobs:
-  # ビルドと静的解析を行うジョブ
   build:
-    name: Build and Lint
-    # ジョブを実行するランナーのOSを指定します。
+    # ビルドジョブ: Pythonパッケージのビルドを行います。
+    name: Build Python Package
     runs-on: ubuntu-latest
-    # ジョブに必要な権限を最小限に設定します。
     permissions:
-      contents: read
-    # ジョブのタイムアウト時間を設定します。
-    timeout-minutes: 10
+      contents: read # リポジトリの読み取り権限のみ
+    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
 
     steps:
+    - name: Checkout repository
       # リポジトリのコードをチェックアウトします。
-      # persist-credentialsはセキュリティのためfalseに設定します。
-      - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      with:
+        persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップし、Poetryをインストールします。
-      # cache: 'poetry' を指定することで、poetry.lockに基づいて依存関係のキャッシュが自動的に管理されます。
-      # 複数バージョンのPythonでテストする場合は、strategy.matrixを使用します。
-      # 例:
-      # strategy:
-      #   matrix:
-      #     python-version: ["3.9", "3.10", "3.11"]
-      # steps:
-      #   - name: Set up Python ${{ matrix.python-version }}
-      #     uses: actions/setup-python@v5
-      #     with:
-      #       python-version: ${{ matrix.python-version }}
-      #       cache: 'poetry'
-      - name: Set up Python 3.11 and Poetry
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
+    - name: Set up Python 3.10
+      # Python環境をセットアップします。
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: '3.10' # ビルドに使用するPythonバージョン
+        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
 
-      # Poetryを使ってプロジェクトの依存関係をインストールします。
-      # --no-interaction と --no-ansi はCI環境での非対話的な実行を保証します。
-      - name: Install dependencies with Poetry
-        run: poetry install --no-interaction --no-ansi
+    - name: Cache Poetry dependencies
+      # Poetryの依存関係をキャッシュし、ビルド時間を短縮します。
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+        key: poetry-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
+        restore-keys: |
+          poetry-${{ runner.os }}-3.10-
+          poetry-${{ runner.os }}-
 
-      # Pythonコードのリンティング（静的解析）を実行します。
-      # Ruffは非常に高速なリンターです。
-      - name: Run Ruff linter
-        run: poetry run ruff check .
+    - name: Install Poetry
+      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
+      run: |
+        curl -sSL https://install.python-poetry.org | python -
+        poetry config virtualenvs.in-project true
 
-      # Pythonコードのフォーマットチェックを実行します。
-      # Blackはコードフォーマッターで、--checkオプションでフォーマット違反がないか確認します。
-      - name: Run Black formatter check
-        run: poetry run black --check .
+    - name: Install dependencies
+      # poetry.lockに基づいて依存関係をインストールします。
+      run: poetry install --no-root --sync
 
-  # テストを実行するジョブ
+    - name: Build package
+      # Pythonパッケージをビルドします。
+      run: poetry build
+
   tests:
-    name: Run Tests
-    # このジョブはbuildジョブが成功した後にのみ実行されます。
-    needs: build
-    # ジョブを実行するランナーのOSを指定します。
+    # テストジョブ: 複数のPythonバージョンでテストと品質チェックを実行します。
+    name: Run Tests and Quality Checks
     runs-on: ubuntu-latest
-    # ジョブに必要な権限を最小限に設定します。
     permissions:
-      contents: read
-    # ジョブのタイムアウト時間を設定します。
-    timeout-minutes: 10
+      contents: read # リポジトリの読み取り権限のみ
+    timeout-minutes: 20 # ジョブの最大実行時間を20分に設定
+
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11'] # 複数のPythonバージョンでテストを実行
 
     steps:
+    - name: Checkout repository
       # リポジトリのコードをチェックアウトします。
-      - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      with:
+        persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップし、Poetryをインストールします。
-      # buildジョブと同様にキャッシュを活用します。
-      - name: Set up Python 3.11 and Poetry
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
+    - name: Set up Python ${{ matrix.python-version }}
+      # Python環境をセットアップします。
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
 
-      # Poetryを使ってプロジェクトの依存関係をインストールします。
-      - name: Install dependencies with Poetry
-        run: poetry install --no-interaction --no-ansi
+    - name: Cache Poetry dependencies
+      # Poetryの依存関係をキャッシュし、テスト時間を短縮します。
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
+        restore-keys: |
+          poetry-${{ runner.os }}-${{ matrix.python-version }}-
+          poetry-${{ runner.os }}-
 
-      # Pytestを使ってユニットテストを実行し、カバレッジレポートを生成します。
-      # --cov=./test は 'test' ディレクトリのコードカバレッジを計測します。
-      # --cov-report=xml はXML形式でカバレッジレポートを出力します。
-      - name: Run unit tests with coverage
-        run: poetry run pytest --cov=./test --cov-report=xml
+    - name: Install Poetry
+      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
+      run: |
+        curl -sSL https://install.python-poetry.org | python -
+        poetry config virtualenvs.in-project true
 
-      # 生成されたカバレッジレポートをアーティファクトとしてアップロードします。
-      # これにより、GitHub Actionsの実行結果からレポートをダウンロードして確認できます。
-      - name: Upload coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: coverage-report
-          path: coverage.xml
+    - name: Install dependencies
+      # poetry.lockに基づいて依存関係と開発ツール（pytest, lintersなど）をインストールします。
+      # pyproject.tomlにdev-dependenciesが定義されている場合、これによってインストールされます。
+      run: poetry install --no-root --sync
+
+    - name: Run linters (Black, Flake8, isort)
+      # コードスタイルと品質チェックを実行します。
+      run: |
+        poetry run black --check .
+        poetry run flake8 .
+        poetry run isort --check-only .
+
+    - name: Run type checker (mypy)
+      # 静的型チェックを実行します。
+      run: poetry run mypy .
+
+    - name: Run tests with coverage
+      # pytestを使用してテストを実行し、カバレッジレポートを生成します。
+      run: poetry run pytest --cov=. --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      # 生成されたカバレッジレポートをCodecovにアップロードします。
+      # プライベートリポジトリの場合や、Codecovの特定の機能を利用する場合は、
+      # secrets.CODECOV_TOKEN を設定する必要がある場合があります。
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+      with:
+        files: ./coverage.xml
+        # token: ${{ secrets.CODECOV_TOKEN }} # 必要に応じて設定

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,32 @@
-name: CI
+name: Python CI/CD Workflow # ワークフローの名前
+
 on:
-  workflow_dispatch:
-    # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
-    # push:
-    #   branches:
-    #     - main # デフォルトブランチ名に合わせて変更してください
-    # pull_request:
-    #   branches:
-    #     - main # デフォルトブランチ名に合わせて変更してください
+  workflow_dispatch: # 手動でワークフローを実行するためのトリガー
+  # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
+  # push:
+  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのpush時に実行
+  # pull_request:
+  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのプルリクエスト時に実行
+
+# 同一ブランチでの重複実行を避けるための設定
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    name: Build and Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    name: Build Python Package # ビルドジョブの名前
+    runs-on: ubuntu-latest # ジョブを実行するOS
+    timeout-minutes: 10 # ジョブの最大実行時間
     permissions:
       contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
 
     steps:
-      - name: Checkout repository # リポジトリをチェックアウト
+      - name: Checkout Repository # リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
@@ -31,58 +35,43 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
 
       - name: Install Poetry # Poetryをインストール
         run: |
           pip install poetry
-          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
 
-      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
-        id: cache-poetry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
-          restore-keys: |
-            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
-
-      - name: Install dependencies # 依存関係をインストール
-        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
-
-      - name: Lint with Flake8 # Flake8でコードのスタイルをチェック
+      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
         run: |
-          pip install flake8 # flake8をインストール
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # エラーのみ表示
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics # 警告も表示するが、CIを失敗させない
+          poetry config virtualenvs.create false
 
-      - name: Check code formatting with Black # Blackでコードのフォーマットをチェック
+      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
         run: |
-          pip install black # blackをインストール
-          black --check . # フォーマット違反がないかチェック（修正はしない）
+          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
 
-      - name: Build package # パッケージをビルド
-        run: poetry build # wheelとsdistを生成
+      - name: Build Python package # Pythonパッケージをビルド
+        run: |
+          poetry build # sdistとwheelを生成
 
-      - name: Upload build artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
+      - name: Upload built artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: dist-${{ matrix.python-version }} # アーティファクト名
+          name: dist-${{ matrix.python-version }} # アーティファクトの名前
           path: dist/ # ビルド成果物のパス
 
   tests:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    name: Run Tests and Lint # テストとリンティングジョブの名前
+    runs-on: ubuntu-latest # ジョブを実行するOS
+    timeout-minutes: 15 # ジョブの最大実行時間
     permissions:
       contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
-    needs: build # buildジョブが成功した後に実行
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
 
     steps:
-      - name: Checkout repository # リポジトリをチェックアウト
+      - name: Checkout Repository # リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
@@ -91,31 +80,37 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
 
       - name: Install Poetry # Poetryをインストール
         run: |
           pip install poetry
-          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
 
-      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
-        id: cache-poetry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
-          restore-keys: |
-            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
-
-      - name: Install dependencies # 依存関係をインストール
-        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
-
-      - name: Run tests with Pytest # Pytestでテストを実行
+      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
         run: |
-          pip install pytest pytest-cov # pytestとカバレッジツールをインストール
-          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing # テストを実行し、カバレッジレポートを生成
+          poetry config virtualenvs.create false
+
+      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
+        run: |
+          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
+          # ruff, pytest, pytest-covなどの開発依存もpyproject.tomlに定義されていればここでインストールされる
+
+      - name: Run Ruff Linter # Ruffを使ってコードの静的解析を実行
+        run: |
+          poetry run ruff check . # プロジェクト全体をチェック
+
+      - name: Run Ruff Formatter Check # Ruffを使ってコードのフォーマットチェックを実行
+        run: |
+          poetry run ruff format --check . # フォーマット違反がないかチェック
+
+      - name: Run Pytest # Pytestを使ってユニットテストを実行
+        run: |
+          poetry run pytest -q --cov=test --cov-report=xml # テストを実行し、カバレッジレポートをXML形式で生成
+        env:
+          PYTHONPATH: . # プロジェクトルートをPYTHONPATHに追加してモジュールをインポート可能にする
 
       - name: Upload coverage report # カバレッジレポートをアーティファクトとしてアップロード
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: coverage-report-${{ matrix.python-version }} # アーティファクト名
+          name: coverage-report-${{ matrix.python-version }} # アーティファクトの名前
           path: coverage.xml # カバレッジレポートのパス

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,19 +37,27 @@ jobs:
       # リポジリのコードをチェックアウトします。
       # persist-credentials: false はセキュリティのベストプラクティスです。
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false
 
-      # Python環境をセットアップし、Poetryをインストールします。
+      # Python環境をセットアップします。
       # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
-      # ここではPython 3.13を指定し、pipx経由でPoetryをインストールします。
-      - name: Set up Python 3.13 and Install Poetry
-        uses: actions/setup-python@v5
+      # ここではPython 3.13を指定し、poetryの依存関係をキャッシュします。
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
           cache: "poetry" # poetryの依存関係をキャッシュします
-          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
+
+      # Poetryをインストールします。
+      # pipx経由でPoetryをインストールし、PATHに追加します。
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pipx
+          python -m pipx ensurepath
+          pipx install poetry
 
       # poetryの依存関係をインストールします。
       # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
@@ -88,17 +96,24 @@ jobs:
     steps:
       # リポジトリのコードをチェックアウトします。
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false
 
-      # Python環境をセットアップし、Poetryをインストールします。
-      - name: Set up Python 3.13 and Install Poetry
-        uses: actions/setup-python@v5
+      # Python環境をセットアップします。
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
           cache: "poetry"
-          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
+
+      # Poetryをインストールします。
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pipx
+          python -m pipx ensurepath
+          pipx install poetry
 
       # poetryの依存関係をインストールします。
       - name: Install dependencies with Poetry
@@ -109,4 +124,4 @@ jobs:
       # pytest-covプラグインを使用してカバレッジレポートを生成します。
       - name: Run unit tests with Pytest
         run: |
-          poetry run pytest --cov=./ --cov-report=xml
+          poetry run pytest --cov=./ --cov-report=xml-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,116 +1,120 @@
-name: Python CI/CD Workflow # ワークフローの名前
+name: Python CI
 
+# ワークフローのトリガーイベントを定義します。
+# workflow_dispatchは手動実行を可能にします。
+# 他のイベント（例: push, pull_request）を追加する場合は、以下のように記述します。
+# on:
+#   push:
+#     branches: [ main ]
+#   pull_request:
+#     branches: [ main ]
+#   workflow_dispatch:
 on:
-  workflow_dispatch: # 手動でワークフローを実行するためのトリガー
-  # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
-  # push:
-  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのpush時に実行
-  # pull_request:
-  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのプルリクエスト時に実行
+  workflow_dispatch:
 
-# 同一ブランチでの重複実行を避けるための設定
+# ジョブの並行実行を制御します。
+# 同じブランチでの重複実行を防ぎ、最新のコミットのみを処理します。
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# ワークフロー内のジョブを定義します。
 jobs:
+  # ビルドジョブ
   build:
-    name: Build Python Package # ビルドジョブの名前
-    runs-on: ubuntu-latest # ジョブを実行するOS
-    timeout-minutes: 10 # ジョブの最大実行時間
+    # ジョブの表示名
+    name: Build and Lint
+    # ジョブが実行されるランナー環境
+    runs-on: ubuntu-latest
+    # ジョブのタイムアウト設定 (分)
+    timeout-minutes: 10
+    # ジョブの権限設定 (最小権限の原則に従う)
     permissions:
-      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
+      contents: read # リポジトリのコードを読み取るために必要
 
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
-
+    # ジョブのステップを定義します。
     steps:
-      - name: Checkout Repository # リポジトリをチェックアウト
+      # リポジリのコードをチェックアウトします。
+      # persist-credentials: false はセキュリティのベストプラクティスです。
+      - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+          persist-credentials: false
 
-      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+      # Python環境をセットアップします。
+      # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
+      # ここではPython 3.13を指定します。
+      - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
+          python-version: "3.13"
+          cache: "poetry" # poetryの依存関係をキャッシュします
 
-      - name: Install Poetry # Poetryをインストール
+      # poetryをインストールします。
+      - name: Install Poetry
         run: |
           pip install poetry
 
-      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
+      # poetryの依存関係をインストールします。
+      # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
+      - name: Install dependencies with Poetry
         run: |
-          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
 
-      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
+      # コードの静的解析 (Lint) を実行します。
+      # flake8を使用してコードスタイルと品質をチェックします。
+      - name: Run Flake8 Lint
         run: |
-          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
+          poetry run flake8 .
 
-      - name: Build Python package # Pythonパッケージをビルド
+      # コードのフォーマットチェック (Black) を実行します。
+      # フォーマット違反がないか確認し、違反があれば失敗させます。
+      - name: Check code format with Black
         run: |
-          poetry build # sdistとwheelを生成
+          poetry run black --check .
 
-      - name: Upload built artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dist-${{ matrix.python-version }} # アーティファクトの名前
-          path: dist/ # ビルド成果物のパス
-
+  # テストジョブ
   tests:
-    name: Run Tests and Lint # テストとリンティングジョブの名前
-    runs-on: ubuntu-latest # ジョブを実行するOS
-    timeout-minutes: 15 # ジョブの最大実行時間
+    # ジョブの表示名
+    name: Run Tests
+    # ジョブが実行されるランナー環境
+    runs-on: ubuntu-latest
+    # ジョブのタイムアウト設定 (分)
+    timeout-minutes: 10
+    # ジョブの権限設定 (最小権限の原則に従う)
     permissions:
-      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
+      contents: read # リポジトリのコードを読み取るために必要
 
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
+    # buildジョブが成功した場合にのみ実行します。
+    needs: build
 
+    # ジョブのステップを定義します。
     steps:
-      - name: Checkout Repository # リポジトリをチェックアウト
+      # リポジトリのコードをチェックアウトします。
+      - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+          persist-credentials: false
 
-      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+      # Python環境をセットアップします。
+      - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
+          python-version: "3.13"
+          cache: "poetry"
 
-      - name: Install Poetry # Poetryをインストール
+      # poetryをインストールします。
+      - name: Install Poetry
         run: |
           pip install poetry
 
-      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
+      # poetryの依存関係をインストールします。
+      - name: Install dependencies with Poetry
         run: |
-          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
 
-      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
+      # pytestを使用してユニットテストを実行します。
+      # pytest-covプラグインを使用してカバレッジレポートを生成します。
+      - name: Run unit tests with Pytest
         run: |
-          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
-          # ruff, pytest, pytest-covなどの開発依存もpyproject.tomlに定義されていればここでインストールされる
-
-      - name: Run Ruff Linter # Ruffを使ってコードの静的解析を実行
-        run: |
-          poetry run ruff check . # プロジェクト全体をチェック
-
-      - name: Run Ruff Formatter Check # Ruffを使ってコードのフォーマットチェックを実行
-        run: |
-          poetry run ruff format --check . # フォーマット違反がないかチェック
-
-      - name: Run Pytest # Pytestを使ってユニットテストを実行
-        run: |
-          poetry run pytest -q --cov=test --cov-report=xml # テストを実行し、カバレッジレポートをXML形式で生成
-        env:
-          PYTHONPATH: . # プロジェクトルートをPYTHONPATHに追加してモジュールをインポート可能にする
-
-      - name: Upload coverage report # カバレッジレポートをアーティファクトとしてアップロード
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: coverage-report-${{ matrix.python-version }} # アーティファクトの名前
-          path: coverage.xml # カバレッジレポートのパス
+          poetry run pytest --cov=./ --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,129 +1,121 @@
-name: Python CI
-
+name: CI
 on:
   workflow_dispatch:
-    # 他のイベントを追加する場合は、以下を参考にしてください。
+    # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
     # push:
-    #   branches: [ main, develop ]
+    #   branches:
+    #     - main # デフォルトブランチ名に合わせて変更してください
     # pull_request:
-    #   branches: [ main, develop ]
-    # schedule:
-    #   - cron: '0 0 * * *' # 毎日深夜0時に実行
+    #   branches:
+    #     - main # デフォルトブランチ名に合わせて変更してください
 
 jobs:
   build:
-    # ビルドジョブ: Pythonパッケージのビルドを行います。
-    name: Build Python Package
+    name: Build and Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
     permissions:
-      contents: read # リポジトリの読み取り権限のみ
-    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
-
-    steps:
-    - name: Checkout repository
-      # リポジトリのコードをチェックアウトします。
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      with:
-        persist-credentials: false # 認証情報を永続化しない
-
-    - name: Set up Python 3.10
-      # Python環境をセットアップします。
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        python-version: '3.10' # ビルドに使用するPythonバージョン
-        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
-
-    - name: Cache Poetry dependencies
-      # Poetryの依存関係をキャッシュし、ビルド時間を短縮します。
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-        key: poetry-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
-        restore-keys: |
-          poetry-${{ runner.os }}-3.10-
-          poetry-${{ runner.os }}-
-
-    - name: Install Poetry
-      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
-      run: |
-        curl -sSL https://install.python-poetry.org | python -
-        poetry config virtualenvs.in-project true
-
-    - name: Install dependencies
-      # poetry.lockに基づいて依存関係をインストールします。
-      run: poetry install --no-root --sync
-
-    - name: Build package
-      # Pythonパッケージをビルドします。
-      run: poetry build
-
-  tests:
-    # テストジョブ: 複数のPythonバージョンでテストと品質チェックを実行します。
-    name: Run Tests and Quality Checks
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # リポジトリの読み取り権限のみ
-    timeout-minutes: 20 # ジョブの最大実行時間を20分に設定
+      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11'] # 複数のPythonバージョンでテストを実行
+        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
 
     steps:
-    - name: Checkout repository
-      # リポジトリのコードをチェックアウトします。
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      with:
-        persist-credentials: false # 認証情報を永続化しない
+      - name: Checkout repository # リポジトリをチェックアウト
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
 
-    - name: Set up Python ${{ matrix.python-version }}
-      # Python環境をセットアップします。
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
+      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Cache Poetry dependencies
-      # Poetryの依存関係をキャッシュし、テスト時間を短縮します。
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
-        restore-keys: |
-          poetry-${{ runner.os }}-${{ matrix.python-version }}-
-          poetry-${{ runner.os }}-
+      - name: Install Poetry # Poetryをインストール
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
 
-    - name: Install Poetry
-      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
-      run: |
-        curl -sSL https://install.python-poetry.org | python -
-        poetry config virtualenvs.in-project true
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        id: cache-poetry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
+          restore-keys: |
+            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
 
-    - name: Install dependencies
-      # poetry.lockに基づいて依存関係と開発ツール（pytest, lintersなど）をインストールします。
-      # pyproject.tomlにdev-dependenciesが定義されている場合、これによってインストールされます。
-      run: poetry install --no-root --sync
+      - name: Install dependencies # 依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
 
-    - name: Run linters (Black, Flake8, isort)
-      # コードスタイルと品質チェックを実行します。
-      run: |
-        poetry run black --check .
-        poetry run flake8 .
-        poetry run isort --check-only .
+      - name: Lint with Flake8 # Flake8でコードのスタイルをチェック
+        run: |
+          pip install flake8 # flake8をインストール
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # エラーのみ表示
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics # 警告も表示するが、CIを失敗させない
 
-    - name: Run type checker (mypy)
-      # 静的型チェックを実行します。
-      run: poetry run mypy .
+      - name: Check code formatting with Black # Blackでコードのフォーマットをチェック
+        run: |
+          pip install black # blackをインストール
+          black --check . # フォーマット違反がないかチェック（修正はしない）
 
-    - name: Run tests with coverage
-      # pytestを使用してテストを実行し、カバレッジレポートを生成します。
-      run: poetry run pytest --cov=. --cov-report=xml
+      - name: Build package # パッケージをビルド
+        run: poetry build # wheelとsdistを生成
 
-    - name: Upload coverage to Codecov
-      # 生成されたカバレッジレポートをCodecovにアップロードします。
-      # プライベートリポジトリの場合や、Codecovの特定の機能を利用する場合は、
-      # secrets.CODECOV_TOKEN を設定する必要がある場合があります。
-      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
-      with:
-        files: ./coverage.xml
-        # token: ${{ secrets.CODECOV_TOKEN }} # 必要に応じて設定
+      - name: Upload build artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist-${{ matrix.python-version }} # アーティファクト名
+          path: dist/ # ビルド成果物のパス
+
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    permissions:
+      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
+
+    needs: build # buildジョブが成功した後に実行
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+
+    steps:
+      - name: Checkout repository # リポジトリをチェックアウト
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+
+      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry # Poetryをインストール
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
+
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        id: cache-poetry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
+          restore-keys: |
+            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
+
+      - name: Install dependencies # 依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
+
+      - name: Run tests with Pytest # Pytestでテストを実行
+        run: |
+          pip install pytest pytest-cov # pytestとカバレッジツールをインストール
+          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing # テストを実行し、カバレッジレポートを生成
+
+      - name: Upload coverage report # カバレッジレポートをアーティファクトとしてアップロード
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-report-${{ matrix.python-version }} # アーティファクト名
+          path: coverage.xml # カバレッジレポートのパス

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,23 +37,19 @@ jobs:
       # リポジリのコードをチェックアウトします。
       # persist-credentials: false はセキュリティのベストプラクティスです。
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # Python環境をセットアップします。
+      # Python環境をセットアップし、Poetryをインストールします。
       # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
-      # ここではPython 3.13を指定します。
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      # ここではPython 3.13を指定し、pipx経由でPoetryをインストールします。
+      - name: Set up Python 3.13 and Install Poetry
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: "poetry" # poetryの依存関係をキャッシュします
-
-      # poetryをインストールします。
-      - name: Install Poetry
-        run: |
-          pip install poetry
+          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
 
       # poetryの依存関係をインストールします。
       # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
@@ -92,21 +88,17 @@ jobs:
     steps:
       # リポジトリのコードをチェックアウトします。
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # Python環境をセットアップします。
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      # Python環境をセットアップし、Poetryをインストールします。
+      - name: Set up Python 3.13 and Install Poetry
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: "poetry"
-
-      # poetryをインストールします。
-      - name: Install Poetry
-        run: |
-          pip install poetry
+          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
 
       # poetryの依存関係をインストールします。
       - name: Install dependencies with Poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,11 @@ jobs:
           cache: "poetry" # poetryの依存関係をキャッシュします
 
       # Poetryをインストールします。
-      # pipx経由でPoetryをインストールし、PATHに追加します。
+      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
       - name: Install Poetry
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pipx
-          python -m pipx ensurepath
-          pipx install poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+        with:
+          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
 
       # poetryの依存関係をインストールします。
       # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
@@ -108,12 +106,11 @@ jobs:
           cache: "poetry"
 
       # Poetryをインストールします。
+      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
       - name: Install Poetry
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pipx
-          python -m pipx ensurepath
-          pipx install poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+        with:
+          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
 
       # poetryの依存関係をインストールします。
       - name: Install dependencies with Poetry
@@ -124,4 +121,4 @@ jobs:
       # pytest-covプラグインを使用してカバレッジレポートを生成します。
       - name: Run unit tests with Pytest
         run: |
-          poetry run pytest --cov=./ --cov-report=xml-
+          poetry run pytest --cov=./ --cov-report=xml


### PR DESCRIPTION
このプルリクエストでは、Pythonプロジェクトの品質を自動的にチェックするためのGitHub Actionsワークフローを導入します。これにより、コードの品質維持とテストの実行が効率化され、開発プロセスがよりスムーズになります。

---

### 1. ワークフロー全体の目的と概要

このワークフローは、Pythonプロジェクトのコードが以下の基準を満たしているかを自動的に確認するためのものです。

*   **コードスタイルと品質のチェック（Lint）**: コードの書き方が統一されているか、潜在的な問題がないかを確認します。
*   **コードフォーマットのチェック**: コードの見た目が統一されているかを確認します。
*   **ユニットテストの実行**: コードが意図した通りに動作するかを確認します。

このワークフローは、手動で実行することができます。

---

### 2. 各ジョブ・ステップの詳細解説

このワークフローは、大きく分けて2つのジョブ（`build`と`tests`）で構成されています。

#### ワークフロー全体の設定

```yaml
name: Python CI
on:
  workflow_dispatch:

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

*   **`name: Python CI`**
    *   **役割・ポイント**: このワークフローの名前です。GitHub Actionsの画面で「Python CI」として表示されます。
*   **`on: workflow_dispatch:`**
    *   **役割・ポイント**: このワークフローが「いつ」実行されるかを定義します。`workflow_dispatch`は、GitHub Actionsの画面から手動でワークフローを実行できるようにする設定です。
    *   **補足説明**: `push`や`pull_request`などのイベントを追加すると、コードがリポジトリにプッシュされたり、プルリクエストが作成されたりしたときに自動的に実行されるようになります。
*   **`concurrency:`**
    *   **役割・ポイント**: 同じブランチで複数のワークフローが同時に実行されるのを防ぎ、常に最新のコミットに対するワークフローだけが実行されるように制御します。
    *   **補足説明**:
        *   `group: ${{ github.workflow }}-${{ github.ref }}`: どの実行をグループとして扱うかを定義します。ここでは「ワークフロー名」と「ブランチ名」の組み合わせでグループ化しています。
        *   `cancel-in-progress: true`: もし同じグループのワークフローが既に実行中であれば、それをキャンセルして、新しくトリガーされたワークフローだけを実行します。これにより、無駄な実行を防ぎ、常に最新の結果が得られます。

#### ジョブ: `build` (コードのビルドと品質チェック)

このジョブでは、コードのダウンロード、Python環境のセットアップ、依存ライブラリのインストール、そしてコードの品質チェック（Lintとフォーマットチェック）を行います。

```yaml
jobs:
  build:
    name: Build and Lint
    runs-on: ubuntu-latest
    timeout-minutes: 10
    permissions:
      contents: read

    steps:
      # ... (各ステップのコードは後述)
```

*   **`name: Build and Lint`**
    *   **役割・ポイント**: このジョブの表示名です。GitHub Actionsの画面で「Build and Lint」として表示されます。
*   **`runs-on: ubuntu-latest`**
    *   **役割・ポイント**: このジョブが実行されるコンピューター環境を指定します。ここでは、最新版のUbuntu Linuxサーバーを使用します。
*   **`timeout-minutes: 10`**
    *   **役割・ポイント**: このジョブが10分を超えても完了しない場合、強制的に終了させます。無限ループや予期せぬフリーズを防ぐための設定です。
*   **`permissions: contents: read`**
    *   **役割・ポイント**: このジョブがリポジトリのコードを読み取るための最小限の権限を与えます。セキュリティの観点から、必要最小限の権限のみを与えるのが良いとされています。

##### ステップ1: リポジトリのコードをチェックアウト

```yaml
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          persist-credentials: false
```

*   **役割・ポイント**: GitHubリポジトリにあるプロジェクトのコードを、ワークフローが実行されるサーバー（`runs-on`で指定したUbuntu）にダウンロードします。
*   **補足説明**:
    *   `actions/checkout@v4`: GitHubが公式に提供しているアクションで、リポジトリのコードをチェックアウト（ダウンロード）するために使われます。
    *   `persist-credentials: false`: ダウンロード時に認証情報を保持しない設定です。セキュリティを向上させるためのベストプラクティスです。

##### ステップ2: Python環境をセットアップ

```yaml
      - name: Set up Python 3.13
        uses: actions/setup-python@v5
        with:
          python-version: "3.13"
          cache: "poetry"
```

*   **役割・ポイント**: ワークフローが実行されるサーバーに、指定されたバージョンのPython（ここではPython 3.13）をセットアップします。また、Pythonのパッケージ管理ツールであるPoetryがダウンロードするライブラリをキャッシュ（一時保存）するように設定します。
*   **補足説明**:
    *   `actions/setup-python@v5`: GitHubが公式に提供しているアクションで、Python環境をセットアップするために使われます。
    *   `python-version: "3.13"`: インストールするPythonのバージョンを指定します。
    *   `cache: "poetry"`: Poetryがインストールする依存ライブラリをキャッシュします。これにより、2回目以降のワークフロー実行時に、同じライブラリのダウンロードが不要になり、実行時間を短縮できます。

##### ステップ3: Poetryをインストール

```yaml
      - name: Install Poetry
        uses: snok/install-poetry@v1
        with:
          version: '1.x.x'
```

*   **役割・ポイント**: Pythonの依存関係管理ツールであるPoetryをインストールします。
*   **補足説明**:
    *   `snok/install-poetry@v1`: コミュニティによって提供されているアクションで、Poetryを簡単にインストールし、システムパスに追加してくれます。
    *   `version: '1.x.x'`: インストールしたいPoetryのバージョンを指定します。`'1.x.x'`は最新の1.x系バージョンを意味しますが、特定のバージョン（例: `'1.8.2'`）に固定することも可能です。

##### ステップ4: Poetryで依存関係をインストール

```yaml
      - name: Install dependencies with Poetry
        run: |
          poetry install --no-interaction --no-ansi
```

*   **役割・ポイント**: プロジェクトの`pyproject.toml`ファイルに記述されている、必要なライブラリ（依存関係）をPoetryを使ってインストールします。
*   **補足説明**:
    *   `poetry install`: `pyproject.toml`と`poetry.lock`ファイルに基づいて依存ライブラリをインストールするPoetryのコマンドです。
    *   `--no-interaction`: インストール中にユーザーからの対話的な入力を求めないようにします。CI/CD環境での自動実行に適しています。
    *   `--no-ansi`: ANSIエスケープシーケンス（ターミナルでの色付けなど）を出力しないようにします。

##### ステップ5: コードの静的解析 (Lint) を実行

```yaml
      - name: Run Flake8 Lint
        run: |
          poetry run flake8 .
```

*   **役割・ポイント**: Pythonコードの静的解析ツールであるFlake8を実行し、コードスタイル（PEP 8など）の違反や、潜在的なバグがないかをチェックします。
*   **補足説明**:
    *   `poetry run`: Poetryで管理されている仮想環境内でコマンドを実行するためのプレフィックスです。これにより、プロジェクト固有のライブラリを使ってコマンドを実行できます。
    *   `flake8 .`: 現在のディレクトリ（`.`）にあるすべてのPythonファイルに対してFlake8を実行します。

##### ステップ6: コードのフォーマットチェック (Black) を実行

```yaml
      - name: Check code format with Black
        run: |
          poetry run black --check .
```

*   **役割・ポイント**: Pythonコードの自動フォーマッターであるBlackを実行し、コードのフォーマットが統一されているかを確認します。もしフォーマット違反があれば、このステップは失敗します。
*   **補足説明**:
    *   `black --check .`: 現在のディレクトリにあるすべてのPythonファイルに対してBlackを実行します。`--check`オプションは、実際にコードを修正するのではなく、フォーマット違反があるかどうかのチェックのみを行います。

#### ジョブ: `tests` (テストの実行)

このジョブでは、`build`ジョブが成功した場合にのみ、コードのダウンロード、Python環境のセットアップ、依存ライブラリのインストール、そしてユニットテストの実行を行います。

```yaml
  tests:
    name: Run Tests
    runs-on: ubuntu-latest
    timeout-minutes: 10
    permissions:
      contents: read
    needs: build

    steps:
      # ... (各ステップのコードは後述)
```

*   **`name: Run Tests`**
    *   **役割・ポイント**: このジョブの表示名です。
*   **`runs-on: ubuntu-latest`**, **`timeout-minutes: 10`**, **`permissions: contents: read`**
    *   **役割・ポイント**: `build`ジョブと同様の設定です。
*   **`needs: build`**
    *   **役割・ポイント**: この`tests`ジョブは、`build`ジョブが**成功した場合にのみ**実行されるように設定されています。これにより、コードの品質チェックが通らない状態でテストを実行する無駄を省くことができます。

##### ステップ1〜4: `build`ジョブと同様のセットアップ

`tests`ジョブは`build`ジョブとは独立した環境で実行されるため、再度以下のステップが必要です。

*   **`Checkout repository`**: リポジトリのコードをダウンロードします。
*   **`Set up Python 3.13`**: Python 3.13環境をセットアップし、Poetryのキャッシュを設定します。
*   **`Install Poetry`**: Poetryをインストールします。
*   **`Install dependencies with Poetry`**: プロジェクトの依存ライブラリをインストールします。

これらのステップの詳細は、`build`ジョブの解説をご参照ください。

##### ステップ5: ユニットテストを実行

```yaml
      - name: Run unit tests with Pytest
        run: |
          poetry run pytest --cov=./ --cov-report=xml
```

*   **役割・ポイント**: PythonのテストフレームワークであるPytestを使って、プロジェクトのユニットテストを実行します。同時に、`--cov`オプションでコードカバレッジ（テストによってどれくらいのコードが実行されたか）を測定し、`--cov-report=xml`でその結果をXML形式のレポートとして出力します。
*   **補足説明**:
    *   `pytest`: Pytestを実行するコマンドです。
    *   `--cov=./`: 現在のディレクトリにあるコードのテストカバレッジを測定します。
    *   `--cov-report=xml`: カバレッジレポートをXML形式で出力します。このXMLファイルは、Codecovなどの外部サービスにアップロードして、カバレッジの変化を視覚的に確認するために利用されることが多いです。

---

### 3. 注意点やよくあるミス

*   **Poetryのバージョン**: `snok/install-poetry@v1`アクションの`version: '1.x.x'`は、常に最新の1.x系バージョンをインストールします。もし特定のPoetryバージョンで動作を保証したい場合は、`'1.8.2'`のように具体的なバージョン番号を指定することをお勧めします。
*   **Pythonバージョン**: `actions/setup-python@v5`アクションの`python-version: "3.13"`は、プロジェクトで実際に使用しているPythonバージョンと一致させてください。`pyproject.toml`や`runtime.txt`などで指定されているバージョンと合わせるのが一般的です。
*   **`needs`の理解**: `needs: build`は、`tests`ジョブが`build`ジョブの成功に依存することを意味しますが、各ジョブは独立した環境で実行されます。そのため、`build`ジョブで生成されたファイルなどを`tests`ジョブで利用したい場合は、`actions/upload-artifact`や`actions/download-artifact`といったアクションを使って、明示的にファイルを共有する必要があります。今回のワークフローでは、各ジョブでコードのチェックアウトと依存関係のインストールを再度行っているため、この点は問題ありません。
*   **権限設定**: `permissions: contents: read`は、リポジトリのコードを読み取るための最小限の権限です。もし、ワークフロー内でGitHubのAPIを呼び出してプルリクエストにコメントしたり、成果物をアップロードしたりする場合は、追加の権限（例: `pull-requests: write`, `statuses: write`など）が必要になることがあります。

このワークフローを導入することで、プロジェクトの品質管理がより自動化され、安定した開発に貢献できることを期待しています。