### PR TITLE
GitHubワークフローファイルの作成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-python-3.13-poetry-
 
-      # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
+      # プロジェクトの依存関係をインストール
+      # `--with dev` オプションは、`pyproject.toml` に `[tool.poetry.group.dev.dependencies]` が定義されていないためエラーになりました。
+      # このオプションを削除することで、現在のエラーは解消されます。
+      # もし `pytest` や `ruff` が見つからないエラーが再発した場合は、
+      # `pyproject.toml` の `[tool.poetry.group.dev.dependencies]` にそれらを定義するか、
+      # `[tool.poetry.dependencies]` に含めることを検討してください。
       - name: Install project dependencies
         run: |
-          poetry install --no-interaction --no-ansi --with dev
+          poetry install --no-interaction --no-ansi
 
       # コードのリンティングとフォーマットチェック (Ruffを使用)
       - name: Run linters and format check
@@ -110,9 +115,14 @@ jobs:
             ${{ runner.os }}-python-3.13-poetry-
 
       # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
+      # `--with dev` オプションは、`pyproject.toml` に `[tool.poetry.group.dev.dependencies]` が定義されていないためエラーになりました。
+      # このオプションを削除することで、現在のエラーは解消されます。
+      # もし `pytest` や `ruff` が見つからないエラーが再発した場合は、
+      # `pyproject.toml` の `[tool.poetry.group.dev.dependencies]` にそれらを定義するか、
+      # `[tool.poetry.dependencies]` に含めることを検討してください。
       - name: Install project dependencies
         run: |
-          poetry install --no-interaction --no-ansi --with dev
+          poetry install --no-interaction --no-ansi
 
       # Pytestでユニットテストを実行し、カバレッジを生成
       - name: Run unit tests with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,114 +1,129 @@
-name: CI
+name: Python CI
 
-# ワークフローのトリガーイベントを設定します。
-# workflow_dispatchは手動実行を可能にします。
-# 他のイベントを追加する場合は、以下のように記述します。
-# on:
-#   push:
-#     branches:
-#       - main
-#   pull_request:
-#     branches:
-#       - main
 on:
   workflow_dispatch:
+    # 他のイベントを追加する場合は、以下を参考にしてください。
+    # push:
+    #   branches: [ main, develop ]
+    # pull_request:
+    #   branches: [ main, develop ]
+    # schedule:
+    #   - cron: '0 0 * * *' # 毎日深夜0時に実行
 
 jobs:
-  # ビルドと静的解析を行うジョブ
   build:
-    name: Build and Lint
-    # ジョブを実行するランナーのOSを指定します。
+    # ビルドジョブ: Pythonパッケージのビルドを行います。
+    name: Build Python Package
     runs-on: ubuntu-latest
-    # ジョブに必要な権限を最小限に設定します。
     permissions:
-      contents: read
-    # ジョブのタイムアウト時間を設定します。
-    timeout-minutes: 10
+      contents: read # リポジトリの読み取り権限のみ
+    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
 
     steps:
+    - name: Checkout repository
       # リポジトリのコードをチェックアウトします。
-      # persist-credentialsはセキュリティのためfalseに設定します。
-      - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      with:
+        persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップし、Poetryをインストールします。
-      # cache: 'poetry' を指定することで、poetry.lockに基づいて依存関係のキャッシュが自動的に管理されます。
-      # 複数バージョンのPythonでテストする場合は、strategy.matrixを使用します。
-      # 例:
-      # strategy:
-      #   matrix:
-      #     python-version: ["3.9", "3.10", "3.11"]
-      # steps:
-      #   - name: Set up Python ${{ matrix.python-version }}
-      #     uses: actions/setup-python@v5
-      #     with:
-      #       python-version: ${{ matrix.python-version }}
-      #       cache: 'poetry'
-      - name: Set up Python 3.11 and Poetry
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
+    - name: Set up Python 3.10
+      # Python環境をセットアップします。
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: '3.10' # ビルドに使用するPythonバージョン
+        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
 
-      # Poetryを使ってプロジェクトの依存関係をインストールします。
-      # --no-interaction と --no-ansi はCI環境での非対話的な実行を保証します。
-      - name: Install dependencies with Poetry
-        run: poetry install --no-interaction --no-ansi
+    - name: Cache Poetry dependencies
+      # Poetryの依存関係をキャッシュし、ビルド時間を短縮します。
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+        key: poetry-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
+        restore-keys: |
+          poetry-${{ runner.os }}-3.10-
+          poetry-${{ runner.os }}-
 
-      # Pythonコードのリンティング（静的解析）を実行します。
-      # Ruffは非常に高速なリンターです。
-      - name: Run Ruff linter
-        run: poetry run ruff check .
+    - name: Install Poetry
+      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
+      run: |
+        curl -sSL https://install.python-poetry.org | python -
+        poetry config virtualenvs.in-project true
 
-      # Pythonコードのフォーマットチェックを実行します。
-      # Blackはコードフォーマッターで、--checkオプションでフォーマット違反がないか確認します。
-      - name: Run Black formatter check
-        run: poetry run black --check .
+    - name: Install dependencies
+      # poetry.lockに基づいて依存関係をインストールします。
+      run: poetry install --no-root --sync
 
-  # テストを実行するジョブ
+    - name: Build package
+      # Pythonパッケージをビルドします。
+      run: poetry build
+
   tests:
-    name: Run Tests
-    # このジョブはbuildジョブが成功した後にのみ実行されます。
-    needs: build
-    # ジョブを実行するランナーのOSを指定します。
+    # テストジョブ: 複数のPythonバージョンでテストと品質チェックを実行します。
+    name: Run Tests and Quality Checks
     runs-on: ubuntu-latest
-    # ジョブに必要な権限を最小限に設定します。
     permissions:
-      contents: read
-    # ジョブのタイムアウト時間を設定します。
-    timeout-minutes: 10
+      contents: read # リポジトリの読み取り権限のみ
+    timeout-minutes: 20 # ジョブの最大実行時間を20分に設定
+
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11'] # 複数のPythonバージョンでテストを実行
 
     steps:
+    - name: Checkout repository
       # リポジトリのコードをチェックアウトします。
-      - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      with:
+        persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップし、Poetryをインストールします。
-      # buildジョブと同様にキャッシュを活用します。
-      - name: Set up Python 3.11 and Poetry
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
+    - name: Set up Python ${{ matrix.python-version }}
+      # Python環境をセットアップします。
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
 
-      # Poetryを使ってプロジェクトの依存関係をインストールします。
-      - name: Install dependencies with Poetry
-        run: poetry install --no-interaction --no-ansi
+    - name: Cache Poetry dependencies
+      # Poetryの依存関係をキャッシュし、テスト時間を短縮します。
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
+        restore-keys: |
+          poetry-${{ runner.os }}-${{ matrix.python-version }}-
+          poetry-${{ runner.os }}-
 
-      # Pytestを使ってユニットテストを実行し、カバレッジレポートを生成します。
-      # --cov=./test は 'test' ディレクトリのコードカバレッジを計測します。
-      # --cov-report=xml はXML形式でカバレッジレポートを出力します。
-      - name: Run unit tests with coverage
-        run: poetry run pytest --cov=./test --cov-report=xml
+    - name: Install Poetry
+      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
+      run: |
+        curl -sSL https://install.python-poetry.org | python -
+        poetry config virtualenvs.in-project true
 
-      # 生成されたカバレッジレポートをアーティファクトとしてアップロードします。
-      # これにより、GitHub Actionsの実行結果からレポートをダウンロードして確認できます。
-      - name: Upload coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: coverage-report
-          path: coverage.xml
+    - name: Install dependencies
+      # poetry.lockに基づいて依存関係と開発ツール（pytest, lintersなど）をインストールします。
+      # pyproject.tomlにdev-dependenciesが定義されている場合、これによってインストールされます。
+      run: poetry install --no-root --sync
+
+    - name: Run linters (Black, Flake8, isort)
+      # コードスタイルと品質チェックを実行します。
+      run: |
+        poetry run black --check .
+        poetry run flake8 .
+        poetry run isort --check-only .
+
+    - name: Run type checker (mypy)
+      # 静的型チェックを実行します。
+      run: poetry run mypy .
+
+    - name: Run tests with coverage
+      # pytestを使用してテストを実行し、カバレッジレポートを生成します。
+      run: poetry run pytest --cov=. --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      # 生成されたカバレッジレポートをCodecovにアップロードします。
+      # プライベートリポジトリの場合や、Codecovの特定の機能を利用する場合は、
+      # secrets.CODECOV_TOKEN を設定する必要がある場合があります。
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+      with:
+        files: ./coverage.xml
+        # token: ${{ secrets.CODECOV_TOKEN }} # 必要に応じて設定

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,32 @@
-name: CI
+name: Python CI/CD Workflow # ワークフローの名前
+
 on:
-  workflow_dispatch:
-    # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
-    # push:
-    #   branches:
-    #     - main # デフォルトブランチ名に合わせて変更してください
-    # pull_request:
-    #   branches:
-    #     - main # デフォルトブランチ名に合わせて変更してください
+  workflow_dispatch: # 手動でワークフローを実行するためのトリガー
+  # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
+  # push:
+  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのpush時に実行
+  # pull_request:
+  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのプルリクエスト時に実行
+
+# 同一ブランチでの重複実行を避けるための設定
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    name: Build and Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    name: Build Python Package # ビルドジョブの名前
+    runs-on: ubuntu-latest # ジョブを実行するOS
+    timeout-minutes: 10 # ジョブの最大実行時間
     permissions:
       contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
 
     steps:
-      - name: Checkout repository # リポジトリをチェックアウト
+      - name: Checkout Repository # リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
@@ -31,58 +35,43 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
 
       - name: Install Poetry # Poetryをインストール
         run: |
           pip install poetry
-          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
 
-      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
-        id: cache-poetry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
-          restore-keys: |
-            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
-
-      - name: Install dependencies # 依存関係をインストール
-        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
-
-      - name: Lint with Flake8 # Flake8でコードのスタイルをチェック
+      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
         run: |
-          pip install flake8 # flake8をインストール
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # エラーのみ表示
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics # 警告も表示するが、CIを失敗させない
+          poetry config virtualenvs.create false
 
-      - name: Check code formatting with Black # Blackでコードのフォーマットをチェック
+      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
         run: |
-          pip install black # blackをインストール
-          black --check . # フォーマット違反がないかチェック（修正はしない）
+          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
 
-      - name: Build package # パッケージをビルド
-        run: poetry build # wheelとsdistを生成
+      - name: Build Python package # Pythonパッケージをビルド
+        run: |
+          poetry build # sdistとwheelを生成
 
-      - name: Upload build artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
+      - name: Upload built artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: dist-${{ matrix.python-version }} # アーティファクト名
+          name: dist-${{ matrix.python-version }} # アーティファクトの名前
           path: dist/ # ビルド成果物のパス
 
   tests:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    name: Run Tests and Lint # テストとリンティングジョブの名前
+    runs-on: ubuntu-latest # ジョブを実行するOS
+    timeout-minutes: 15 # ジョブの最大実行時間
     permissions:
       contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
-    needs: build # buildジョブが成功した後に実行
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
 
     steps:
-      - name: Checkout repository # リポジトリをチェックアウト
+      - name: Checkout Repository # リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
@@ -91,31 +80,37 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
 
       - name: Install Poetry # Poetryをインストール
         run: |
           pip install poetry
-          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
 
-      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
-        id: cache-poetry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
-          restore-keys: |
-            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
-
-      - name: Install dependencies # 依存関係をインストール
-        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
-
-      - name: Run tests with Pytest # Pytestでテストを実行
+      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
         run: |
-          pip install pytest pytest-cov # pytestとカバレッジツールをインストール
-          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing # テストを実行し、カバレッジレポートを生成
+          poetry config virtualenvs.create false
+
+      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
+        run: |
+          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
+          # ruff, pytest, pytest-covなどの開発依存もpyproject.tomlに定義されていればここでインストールされる
+
+      - name: Run Ruff Linter # Ruffを使ってコードの静的解析を実行
+        run: |
+          poetry run ruff check . # プロジェクト全体をチェック
+
+      - name: Run Ruff Formatter Check # Ruffを使ってコードのフォーマットチェックを実行
+        run: |
+          poetry run ruff format --check . # フォーマット違反がないかチェック
+
+      - name: Run Pytest # Pytestを使ってユニットテストを実行
+        run: |
+          poetry run pytest -q --cov=test --cov-report=xml # テストを実行し、カバレッジレポートをXML形式で生成
+        env:
+          PYTHONPATH: . # プロジェクトルートをPYTHONPATHに追加してモジュールをインポート可能にする
 
       - name: Upload coverage report # カバレッジレポートをアーティファクトとしてアップロード
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: coverage-report-${{ matrix.python-version }} # アーティファクト名
+          name: coverage-report-${{ matrix.python-version }} # アーティファクトの名前
           path: coverage.xml # カバレッジレポートのパス

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,19 +37,27 @@ jobs:
       # リポジリのコードをチェックアウトします。
       # persist-credentials: false はセキュリティのベストプラクティスです。
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false
 
-      # Python環境をセットアップし、Poetryをインストールします。
+      # Python環境をセットアップします。
       # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
-      # ここではPython 3.13を指定し、pipx経由でPoetryをインストールします。
-      - name: Set up Python 3.13 and Install Poetry
-        uses: actions/setup-python@v5
+      # ここではPython 3.13を指定し、poetryの依存関係をキャッシュします。
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
           cache: "poetry" # poetryの依存関係をキャッシュします
-          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
+
+      # Poetryをインストールします。
+      # pipx経由でPoetryをインストールし、PATHに追加します。
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pipx
+          python -m pipx ensurepath
+          pipx install poetry
 
       # poetryの依存関係をインストールします。
       # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
@@ -88,17 +96,24 @@ jobs:
     steps:
       # リポジトリのコードをチェックアウトします。
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false
 
-      # Python環境をセットアップし、Poetryをインストールします。
-      - name: Set up Python 3.13 and Install Poetry
-        uses: actions/setup-python@v5
+      # Python環境をセットアップします。
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
           cache: "poetry"
-          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
+
+      # Poetryをインストールします。
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pipx
+          python -m pipx ensurepath
+          pipx install poetry
 
       # poetryの依存関係をインストールします。
       - name: Install dependencies with Poetry
@@ -109,4 +124,4 @@ jobs:
       # pytest-covプラグインを使用してカバレッジレポートを生成します。
       - name: Run unit tests with Pytest
         run: |
-          poetry run pytest --cov=./ --cov-report=xml
+          poetry run pytest --cov=./ --cov-report=xml-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,124 +1,126 @@
 name: Python CI
 
-# ワークフローのトリガーイベントを定義します。
-# workflow_dispatchは手動実行を可能にします。
-# 他のイベント（例: push, pull_request）を追加する場合は、以下のように記述します。
-# on:
-#   push:
-#     branches: [ main ]
-#   pull_request:
-#     branches: [ main ]
-#   workflow_dispatch:
 on:
+  # 手動でワークフローを実行するためのイベント
   workflow_dispatch:
+  # 他のイベントを追加する場合は、以下のコメントアウトを解除してください
+  # push:
+  #   branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
 
-# ジョブの並行実行を制御します。
-# 同じブランチでの重複実行を防ぎ、最新のコミットのみを処理します。
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-# ワークフロー内のジョブを定義します。
 jobs:
-  # ビルドジョブ
   build:
-    # ジョブの表示名
+    # ビルドジョブの名前
     name: Build and Lint
-    # ジョブが実行されるランナー環境
+    # ジョブが実行されるランナーのOS
     runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定 (分)
+    # ジョブのタイムアウト設定
     timeout-minutes: 10
-    # ジョブの権限設定 (最小権限の原則に従う)
+    # ジョブの権限設定 (成果物のアップロードのため write 権限が必要)
     permissions:
-      contents: read # リポジトリのコードを読み取るために必要
+      contents: write
 
-    # ジョブのステップを定義します。
     steps:
-      # リポジリのコードをチェックアウトします。
-      # persist-credentials: false はセキュリティのベストプラクティスです。
+      # コードをチェックアウト
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false
+          persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップします。
-      # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
-      # ここではPython 3.13を指定し、poetryの依存関係をキャッシュします。
-      - name: Set up Python 3.13
+      # Python環境をセットアップ
+      - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13"
-          cache: "poetry" # poetryの依存関係をキャッシュします
+          python-version: '3.12' # Python 3.12を使用。プロジェクトがPython 3.13をターゲットとしている場合は、GitHub Actionsで利用可能になり次第 '3.13' に変更を検討してください。
 
-      # Poetryをインストールします。
-      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
+      # Poetryをインストール
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
-        with:
-          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
+        run: |
+          pip install poetry
 
-      # poetryの依存関係をインストールします。
-      # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
-      - name: Install dependencies with Poetry
+      # Poetryの依存関係キャッシュを復元/保存
+      - name: Cache Poetry dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+          key: ${{ runner.os }}-python-3.12-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-3.12-poetry-
+
+      # プロジェクトの依存関係をインストール
+      - name: Install project dependencies
         run: |
           poetry install --no-interaction --no-ansi
 
-      # コードの静的解析 (Lint) を実行します。
-      # flake8を使用してコードスタイルと品質をチェックします。
-      - name: Run Flake8 Lint
+      # コードのリンティングとフォーマットチェック (Ruffを使用)
+      - name: Run linters and format check
         run: |
-          poetry run flake8 .
+          poetry run ruff check .
+          poetry run ruff format . --check
 
-      # コードのフォーマットチェック (Black) を実行します。
-      # フォーマット違反がないか確認し、違反があれば失敗させます。
-      - name: Check code format with Black
+      # パッケージをビルド
+      - name: Build package
         run: |
-          poetry run black --check .
+          poetry build
 
-  # テストジョブ
+      # ビルドされたパッケージをアーティファクトとしてアップロード
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist
+          path: dist/
+
   tests:
-    # ジョブの表示名
-    name: Run Tests
-    # ジョブが実行されるランナー環境
+    # テストジョブの名前
+    name: Run Unit Tests
+    # ジョブが実行されるランナーのOS
     runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定 (分)
+    # ジョブのタイムアウト設定
     timeout-minutes: 10
-    # ジョブの権限設定 (最小権限の原則に従う)
+    # ジョブの権限設定 (コードの読み取りのみのため read 権限)
     permissions:
-      contents: read # リポジトリのコードを読み取るために必要
+      contents: read
 
-    # buildジョブが成功した場合にのみ実行します。
-    needs: build
-
-    # ジョブのステップを定義します。
     steps:
-      # リポジトリのコードをチェックアウトします。
+      # コードをチェックアウト
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false
+          persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップします。
-      - name: Set up Python 3.13
+      # Python環境をセットアップ
+      - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13"
-          cache: "poetry"
+          python-version: '3.12' # Python 3.12を使用。プロジェクトがPython 3.13をターゲットとしている場合は、GitHub Actionsで利用可能になり次第 '3.13' に変更を検討してください。
 
-      # Poetryをインストールします。
-      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
+      # Poetryをインストール
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
-        with:
-          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
+        run: |
+          pip install poetry
 
-      # poetryの依存関係をインストールします。
-      - name: Install dependencies with Poetry
+      # Poetryの依存関係キャッシュを復元/保存
+      - name: Cache Poetry dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+          key: ${{ runner.os }}-python-3.12-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-3.12-poetry-
+
+      # プロジェクトの依存関係をインストール
+      - name: Install project dependencies
         run: |
           poetry install --no-interaction --no-ansi
 
-      # pytestを使用してユニットテストを実行します。
-      # pytest-covプラグインを使用してカバレッジレポートを生成します。
-      - name: Run unit tests with Pytest
+      # Pytestでユニットテストを実行し、カバレッジを生成
+      - name: Run unit tests with coverage
         run: |
-          poetry run pytest --cov=./ --cov-report=xml
+          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing
+        # カバレッジレポートをアーティファクトとしてアップロードする場合は、permissions: contents: write が必要です
+        # - name: Upload coverage report
+        #   uses: actions/upload-artifact@v4
+        #   with:
+        #     name: coverage-report
+        #     path: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,116 +1,120 @@
-name: Python CI/CD Workflow # ワークフローの名前
+name: Python CI
 
+# ワークフローのトリガーイベントを定義します。
+# workflow_dispatchは手動実行を可能にします。
+# 他のイベント（例: push, pull_request）を追加する場合は、以下のように記述します。
+# on:
+#   push:
+#     branches: [ main ]
+#   pull_request:
+#     branches: [ main ]
+#   workflow_dispatch:
 on:
-  workflow_dispatch: # 手動でワークフローを実行するためのトリガー
-  # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
-  # push:
-  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのpush時に実行
-  # pull_request:
-  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのプルリクエスト時に実行
+  workflow_dispatch:
 
-# 同一ブランチでの重複実行を避けるための設定
+# ジョブの並行実行を制御します。
+# 同じブランチでの重複実行を防ぎ、最新のコミットのみを処理します。
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# ワークフロー内のジョブを定義します。
 jobs:
+  # ビルドジョブ
   build:
-    name: Build Python Package # ビルドジョブの名前
-    runs-on: ubuntu-latest # ジョブを実行するOS
-    timeout-minutes: 10 # ジョブの最大実行時間
+    # ジョブの表示名
+    name: Build and Lint
+    # ジョブが実行されるランナー環境
+    runs-on: ubuntu-latest
+    # ジョブのタイムアウト設定 (分)
+    timeout-minutes: 10
+    # ジョブの権限設定 (最小権限の原則に従う)
     permissions:
-      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
+      contents: read # リポジトリのコードを読み取るために必要
 
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
-
+    # ジョブのステップを定義します。
     steps:
-      - name: Checkout Repository # リポジトリをチェックアウト
+      # リポジリのコードをチェックアウトします。
+      # persist-credentials: false はセキュリティのベストプラクティスです。
+      - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+          persist-credentials: false
 
-      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+      # Python環境をセットアップします。
+      # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
+      # ここではPython 3.13を指定します。
+      - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
+          python-version: "3.13"
+          cache: "poetry" # poetryの依存関係をキャッシュします
 
-      - name: Install Poetry # Poetryをインストール
+      # poetryをインストールします。
+      - name: Install Poetry
         run: |
           pip install poetry
 
-      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
+      # poetryの依存関係をインストールします。
+      # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
+      - name: Install dependencies with Poetry
         run: |
-          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
 
-      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
+      # コードの静的解析 (Lint) を実行します。
+      # flake8を使用してコードスタイルと品質をチェックします。
+      - name: Run Flake8 Lint
         run: |
-          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
+          poetry run flake8 .
 
-      - name: Build Python package # Pythonパッケージをビルド
+      # コードのフォーマットチェック (Black) を実行します。
+      # フォーマット違反がないか確認し、違反があれば失敗させます。
+      - name: Check code format with Black
         run: |
-          poetry build # sdistとwheelを生成
+          poetry run black --check .
 
-      - name: Upload built artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dist-${{ matrix.python-version }} # アーティファクトの名前
-          path: dist/ # ビルド成果物のパス
-
+  # テストジョブ
   tests:
-    name: Run Tests and Lint # テストとリンティングジョブの名前
-    runs-on: ubuntu-latest # ジョブを実行するOS
-    timeout-minutes: 15 # ジョブの最大実行時間
+    # ジョブの表示名
+    name: Run Tests
+    # ジョブが実行されるランナー環境
+    runs-on: ubuntu-latest
+    # ジョブのタイムアウト設定 (分)
+    timeout-minutes: 10
+    # ジョブの権限設定 (最小権限の原則に従う)
     permissions:
-      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
+      contents: read # リポジトリのコードを読み取るために必要
 
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
+    # buildジョブが成功した場合にのみ実行します。
+    needs: build
 
+    # ジョブのステップを定義します。
     steps:
-      - name: Checkout Repository # リポジトリをチェックアウト
+      # リポジトリのコードをチェックアウトします。
+      - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+          persist-credentials: false
 
-      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+      # Python環境をセットアップします。
+      - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
+          python-version: "3.13"
+          cache: "poetry"
 
-      - name: Install Poetry # Poetryをインストール
+      # poetryをインストールします。
+      - name: Install Poetry
         run: |
           pip install poetry
 
-      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
+      # poetryの依存関係をインストールします。
+      - name: Install dependencies with Poetry
         run: |
-          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
 
-      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
+      # pytestを使用してユニットテストを実行します。
+      # pytest-covプラグインを使用してカバレッジレポートを生成します。
+      - name: Run unit tests with Pytest
         run: |
-          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
-          # ruff, pytest, pytest-covなどの開発依存もpyproject.tomlに定義されていればここでインストールされる
-
-      - name: Run Ruff Linter # Ruffを使ってコードの静的解析を実行
-        run: |
-          poetry run ruff check . # プロジェクト全体をチェック
-
-      - name: Run Ruff Formatter Check # Ruffを使ってコードのフォーマットチェックを実行
-        run: |
-          poetry run ruff format --check . # フォーマット違反がないかチェック
-
-      - name: Run Pytest # Pytestを使ってユニットテストを実行
-        run: |
-          poetry run pytest -q --cov=test --cov-report=xml # テストを実行し、カバレッジレポートをXML形式で生成
-        env:
-          PYTHONPATH: . # プロジェクトルートをPYTHONPATHに追加してモジュールをインポート可能にする
-
-      - name: Upload coverage report # カバレッジレポートをアーティファクトとしてアップロード
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: coverage-report-${{ matrix.python-version }} # アーティファクトの名前
-          path: coverage.xml # カバレッジレポートのパス
+          poetry run pytest --cov=./ --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,129 +1,121 @@
-name: Python CI
-
+name: CI
 on:
   workflow_dispatch:
-    # 他のイベントを追加する場合は、以下を参考にしてください。
+    # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
     # push:
-    #   branches: [ main, develop ]
+    #   branches:
+    #     - main # デフォルトブランチ名に合わせて変更してください
     # pull_request:
-    #   branches: [ main, develop ]
-    # schedule:
-    #   - cron: '0 0 * * *' # 毎日深夜0時に実行
+    #   branches:
+    #     - main # デフォルトブランチ名に合わせて変更してください
 
 jobs:
   build:
-    # ビルドジョブ: Pythonパッケージのビルドを行います。
-    name: Build Python Package
+    name: Build and Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
     permissions:
-      contents: read # リポジトリの読み取り権限のみ
-    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
-
-    steps:
-    - name: Checkout repository
-      # リポジトリのコードをチェックアウトします。
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      with:
-        persist-credentials: false # 認証情報を永続化しない
-
-    - name: Set up Python 3.10
-      # Python環境をセットアップします。
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        python-version: '3.10' # ビルドに使用するPythonバージョン
-        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
-
-    - name: Cache Poetry dependencies
-      # Poetryの依存関係をキャッシュし、ビルド時間を短縮します。
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-        key: poetry-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
-        restore-keys: |
-          poetry-${{ runner.os }}-3.10-
-          poetry-${{ runner.os }}-
-
-    - name: Install Poetry
-      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
-      run: |
-        curl -sSL https://install.python-poetry.org | python -
-        poetry config virtualenvs.in-project true
-
-    - name: Install dependencies
-      # poetry.lockに基づいて依存関係をインストールします。
-      run: poetry install --no-root --sync
-
-    - name: Build package
-      # Pythonパッケージをビルドします。
-      run: poetry build
-
-  tests:
-    # テストジョブ: 複数のPythonバージョンでテストと品質チェックを実行します。
-    name: Run Tests and Quality Checks
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # リポジトリの読み取り権限のみ
-    timeout-minutes: 20 # ジョブの最大実行時間を20分に設定
+      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11'] # 複数のPythonバージョンでテストを実行
+        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
 
     steps:
-    - name: Checkout repository
-      # リポジトリのコードをチェックアウトします。
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      with:
-        persist-credentials: false # 認証情報を永続化しない
+      - name: Checkout repository # リポジトリをチェックアウト
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
 
-    - name: Set up Python ${{ matrix.python-version }}
-      # Python環境をセットアップします。
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
+      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Cache Poetry dependencies
-      # Poetryの依存関係をキャッシュし、テスト時間を短縮します。
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
-        restore-keys: |
-          poetry-${{ runner.os }}-${{ matrix.python-version }}-
-          poetry-${{ runner.os }}-
+      - name: Install Poetry # Poetryをインストール
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
 
-    - name: Install Poetry
-      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
-      run: |
-        curl -sSL https://install.python-poetry.org | python -
-        poetry config virtualenvs.in-project true
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        id: cache-poetry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
+          restore-keys: |
+            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
 
-    - name: Install dependencies
-      # poetry.lockに基づいて依存関係と開発ツール（pytest, lintersなど）をインストールします。
-      # pyproject.tomlにdev-dependenciesが定義されている場合、これによってインストールされます。
-      run: poetry install --no-root --sync
+      - name: Install dependencies # 依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
 
-    - name: Run linters (Black, Flake8, isort)
-      # コードスタイルと品質チェックを実行します。
-      run: |
-        poetry run black --check .
-        poetry run flake8 .
-        poetry run isort --check-only .
+      - name: Lint with Flake8 # Flake8でコードのスタイルをチェック
+        run: |
+          pip install flake8 # flake8をインストール
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # エラーのみ表示
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics # 警告も表示するが、CIを失敗させない
 
-    - name: Run type checker (mypy)
-      # 静的型チェックを実行します。
-      run: poetry run mypy .
+      - name: Check code formatting with Black # Blackでコードのフォーマットをチェック
+        run: |
+          pip install black # blackをインストール
+          black --check . # フォーマット違反がないかチェック（修正はしない）
 
-    - name: Run tests with coverage
-      # pytestを使用してテストを実行し、カバレッジレポートを生成します。
-      run: poetry run pytest --cov=. --cov-report=xml
+      - name: Build package # パッケージをビルド
+        run: poetry build # wheelとsdistを生成
 
-    - name: Upload coverage to Codecov
-      # 生成されたカバレッジレポートをCodecovにアップロードします。
-      # プライベートリポジトリの場合や、Codecovの特定の機能を利用する場合は、
-      # secrets.CODECOV_TOKEN を設定する必要がある場合があります。
-      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
-      with:
-        files: ./coverage.xml
-        # token: ${{ secrets.CODECOV_TOKEN }} # 必要に応じて設定
+      - name: Upload build artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist-${{ matrix.python-version }} # アーティファクト名
+          path: dist/ # ビルド成果物のパス
+
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    permissions:
+      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
+
+    needs: build # buildジョブが成功した後に実行
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+
+    steps:
+      - name: Checkout repository # リポジトリをチェックアウト
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+
+      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry # Poetryをインストール
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
+
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        id: cache-poetry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
+          restore-keys: |
+            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
+
+      - name: Install dependencies # 依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
+
+      - name: Run tests with Pytest # Pytestでテストを実行
+        run: |
+          pip install pytest pytest-cov # pytestとカバレッジツールをインストール
+          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing # テストを実行し、カバレッジレポートを生成
+
+      - name: Upload coverage report # カバレッジレポートをアーティファクトとしてアップロード
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-report-${{ matrix.python-version }} # アーティファクト名
+          path: coverage.xml # カバレッジレポートのパス

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,136 +1,97 @@
 name: Python CI
 
 on:
-  # 手動でワークフローを実行するためのイベント
   workflow_dispatch:
-  # 他のイベントを追加する場合は、以下のコメントアウトを解除してください
-  # push:
-  #   branches: [ main ]
-  # pull_request:
-  #   branches: [ main ]
+    # 他のイベントを追加する場合は、以下のように記述します。
+    # push:
+    #   branches:
+    #     - main
+    # pull_request:
+    #   branches:
+    #     - main
 
 jobs:
   build:
     # ビルドジョブの名前
-    name: Build and Lint
-    # ジョブが実行されるランナーのOS
+    name: Build
+    # ジョブの実行環境
     runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定
+    # ジョブのタイムアウト設定 (分)
     timeout-minutes: 10
-    # ジョブの権限設定 (成果物のアップロードのため write 権限が必要)
-    permissions:
-      contents: write
-
-    steps:
-      # コードをチェックアウト
-      - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false # 認証情報を永続化しない
-
-      # Python環境をセットアップ
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.13' # プロジェクトの要件に合わせてPython 3.13に修正
-
-      # Poetryをインストール
-      - name: Install Poetry
-        run: |
-          pip install poetry
-
-      # Poetryの依存関係キャッシュを復元/保存
-      - name: Cache Poetry dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
-          restore-keys: |
-            ${{ runner.os }}-python-3.13-poetry-
-
-      # プロジェクトの依存関係をインストール
-      # `--with dev` オプションは、`pyproject.toml` に `[tool.poetry.group.dev.dependencies]` が定義されていないためエラーになりました。
-      # このオプションを削除することで、現在のエラーは解消されます。
-      # もし `pytest` や `ruff` が見つからないエラーが再発した場合は、
-      # `pyproject.toml` の `[tool.poetry.group.dev.dependencies]` にそれらを定義するか、
-      # `[tool.poetry.dependencies]` に含めることを検討してください。
-      - name: Install project dependencies
-        run: |
-          poetry install --no-interaction --no-ansi
-
-      # コードのリンティングとフォーマットチェック (Ruffを使用)
-      - name: Run linters and format check
-        run: |
-          poetry run ruff check .
-          poetry run ruff format . --check
-
-      # パッケージをビルド
-      - name: Build package
-        run: |
-          poetry build
-
-      # ビルドされたパッケージをアーティファクトとしてアップロード
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dist
-          path: dist/
-
-  tests:
-    # テストジョブの名前
-    name: Run Unit Tests
-    # ジョブが実行されるランナーのOS
-    runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定
-    timeout-minutes: 10
-    # ジョブの権限設定 (コードの読み取りのみのため read 権限)
+    # ジョブの権限設定 (最小権限)
     permissions:
       contents: read
 
     steps:
-      # コードをチェックアウト
+      # リポジトリのチェックアウト
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false # 認証情報を永続化しない
+          # 認証情報を永続化しない (セキュリティのため)
+          persist-credentials: false
 
-      # Python環境をセットアップ
+      # Python環境のセットアップ
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.13' # プロジェクトの要件に合わせてPython 3.13に修正
+          # プロジェクトで指定されているPythonバージョン
+          python-version: "3.13"
+          # Poetryのキャッシュを有効化
+          cache: "poetry"
 
-      # Poetryをインストール
-      - name: Install Poetry
+      # Poetryの依存関係をインストール
+      - name: Install Poetry dependencies
+        # Poetryの仮想環境作成を無効化し、システムPythonにインストール
         run: |
-          pip install poetry
-
-      # Poetryの依存関係キャッシュを復元/保存
-      - name: Cache Poetry dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
-          restore-keys: |
-            ${{ runner.os }}-python-3.13-poetry-
-
-      # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
-      # `--with dev` オプションは、`pyproject.toml` に `[tool.poetry.group.dev.dependencies]` が定義されていないためエラーになりました。
-      # このオプションを削除することで、現在のエラーは解消されます。
-      # もし `pytest` や `ruff` が見つからないエラーが再発した場合は、
-      # `pyproject.toml` の `[tool.poetry.group.dev.dependencies]` にそれらを定義するか、
-      # `[tool.poetry.dependencies]` に含めることを検討してください。
-      - name: Install project dependencies
-        run: |
+          poetry config virtualenvs.create false
           poetry install --no-interaction --no-ansi
 
-      # Pytestでユニットテストを実行し、カバレッジを生成
-      - name: Run unit tests with coverage
+  tests:
+    # テストジョブの名前
+    name: Run Tests
+    # ビルドジョブが成功した後に実行
+    needs: build
+    # ジョブの実行環境
+    runs-on: ubuntu-latest
+    # ジョブのタイムアウト設定 (分)
+    timeout-minutes: 10
+    # ジョブの権限設定 (最小権限)
+    permissions:
+      contents: read
+
+    steps:
+      # リポジトリのチェックアウト
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          # 認証情報を永続化しない (セキュリティのため)
+          persist-credentials: false
+
+      # Python環境のセットアップ
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          # プロジェクトで指定されているPythonバージョン
+          python-version: "3.13"
+          # Poetryのキャッシュを有効化
+          cache: "poetry"
+
+      # Poetryの依存関係をインストール
+      - name: Install Poetry dependencies
+        # Poetryの仮想環境作成を無効化し、システムPythonにインストール
         run: |
-          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing
-        # カバレッジレポートをアーティファクトとしてアップロードする場合は、permissions: contents: write が必要です
-        # - name: Upload coverage report
-        #   uses: actions/upload-artifact@v4
-        #   with:
-        #     name: coverage-report
-        #     path: coverage.xml
+          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
+
+      # テストの実行
+      - name: Run unit tests
+        # unittestを使ってテストを実行
+        run: python -m unittest discover tests
+        # 静的解析ツール (flake8, black, mypyなど) を追加する場合は、ここにステップを追加します。
+        # 例:
+        # - name: Run Flake8
+        #   run: poetry run flake8 .
+        # - name: Run Black
+        #   run: poetry run black --check .
+        # - name: Run MyPy
+        #   run: poetry run mypy .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,23 +37,19 @@ jobs:
       # リポジリのコードをチェックアウトします。
       # persist-credentials: false はセキュリティのベストプラクティスです。
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # Python環境をセットアップします。
+      # Python環境をセットアップし、Poetryをインストールします。
       # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
-      # ここではPython 3.13を指定します。
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      # ここではPython 3.13を指定し、pipx経由でPoetryをインストールします。
+      - name: Set up Python 3.13 and Install Poetry
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: "poetry" # poetryの依存関係をキャッシュします
-
-      # poetryをインストールします。
-      - name: Install Poetry
-        run: |
-          pip install poetry
+          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
 
       # poetryの依存関係をインストールします。
       # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
@@ -92,21 +88,17 @@ jobs:
     steps:
       # リポジトリのコードをチェックアウトします。
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # Python環境をセットアップします。
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      # Python環境をセットアップし、Poetryをインストールします。
+      - name: Set up Python 3.13 and Install Poetry
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: "poetry"
-
-      # poetryをインストールします。
-      - name: Install Poetry
-        run: |
-          pip install poetry
+          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
 
       # poetryの依存関係をインストールします。
       - name: Install dependencies with Poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
     steps:
       # リポジトリのチェックアウト
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           # 認証情報を永続化しない (セキュリティのため)
           persist-credentials: false
 
       # Python環境のセットアップ
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@v5
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
@@ -41,7 +41,9 @@ jobs:
 
       # Poetryのインストール
       - name: Install Poetry
-        run: pip install poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies
@@ -66,14 +68,14 @@ jobs:
     steps:
       # リポジトリのチェックアウト
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           # 認証情報を永続化しない (セキュリティのため)
           persist-credentials: false
 
       # Python環境のセットアップ
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@v5
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
@@ -82,7 +84,9 @@ jobs:
 
       # Poetryのインストール
       - name: Install Poetry
-        run: pip install poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,12 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
           key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
           restore-keys: |
-            ${{ runner.os }}-python-3.13-poetry- # Pythonバージョンを3.13に更新
+            ${{ runner.os }}-python-3.13-poetry-
 
-      # プロジェクトの依存関係をインストール
+      # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
       - name: Install project dependencies
         run: |
-          poetry install --no-interaction --no-ansi
+          poetry install --no-interaction --no-ansi --with dev
 
       # コードのリンティングとフォーマットチェック (Ruffを使用)
       - name: Run linters and format check
@@ -107,12 +107,12 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
           key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
           restore-keys: |
-            ${{ runner.os }}-python-3.13-poetry- # Pythonバージョンを3.13に更新
+            ${{ runner.os }}-python-3.13-poetry-
 
-      # プロジェクトの依存関係をインストール
+      # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
       - name: Install project dependencies
         run: |
-          poetry install --no-interaction --no-ansi
+          poetry install --no-interaction --no-ansi --with dev
 
       # Pytestでユニットテストを実行し、カバレッジを生成
       - name: Run unit tests with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,12 @@ jobs:
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
-          # Poetryのキャッシュを有効化
+          # Poetryの依存関係キャッシュを有効化
           cache: "poetry"
+
+      # Poetryのインストール
+      - name: Install Poetry
+        run: pip install poetry
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies
@@ -73,8 +77,12 @@ jobs:
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
-          # Poetryのキャッシュを有効化
+          # Poetryの依存関係キャッシュを有効化
           cache: "poetry"
+
+      # Poetryのインストール
+      - name: Install Poetry
+        run: pip install poetry
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies
@@ -85,8 +93,8 @@ jobs:
 
       # テストの実行
       - name: Run unit tests
-        # unittestを使ってテストを実行
-        run: python -m unittest discover tests
+        # poetry run を使って、Poetryが管理する環境でコマンドを実行
+        run: poetry run python -m unittest discover tests
         # 静的解析ツール (flake8, black, mypyなど) を追加する場合は、ここにステップを追加します。
         # 例:
         # - name: Run Flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12' # Python 3.12を使用。プロジェクトがPython 3.13をターゲットとしている場合は、GitHub Actionsで利用可能になり次第 '3.13' に変更を検討してください。
+          python-version: '3.13' # プロジェクトの要件に合わせてPython 3.13に修正
 
       # Poetryをインストール
       - name: Install Poetry
@@ -44,9 +44,9 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-3.12-poetry-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
           restore-keys: |
-            ${{ runner.os }}-python-3.12-poetry-
+            ${{ runner.os }}-python-3.13-poetry- # Pythonバージョンを3.13に更新
 
       # プロジェクトの依存関係をインストール
       - name: Install project dependencies
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12' # Python 3.12を使用。プロジェクトがPython 3.13をターゲットとしている場合は、GitHub Actionsで利用可能になり次第 '3.13' に変更を検討してください。
+          python-version: '3.13' # プロジェクトの要件に合わせてPython 3.13に修正
 
       # Poetryをインストール
       - name: Install Poetry
@@ -105,9 +105,9 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-3.12-poetry-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
           restore-keys: |
-            ${{ runner.os }}-python-3.12-poetry-
+            ${{ runner.os }}-python-3.13-poetry- # Pythonバージョンを3.13に更新
 
       # プロジェクトの依存関係をインストール
       - name: Install project dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,24 @@ jobs:
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
-          # Poetryの依存関係キャッシュを有効化
-          cache: "poetry"
+          # actions/setup-pythonのcacheオプションはpoetry自体をインストールしないため削除
 
       # Poetryのインストール
       - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+        run: pip install poetry
+
+      # Poetryキャッシュディレクトリの設定
+      - name: Set Poetry cache directory
+        run: echo "POETRY_CACHE_DIR=$(poetry config cache-dir)" >> $GITHUB_ENV
+
+      # Poetry依存関係キャッシュの復元
+      - name: Restore Poetry dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.POETRY_CACHE_DIR }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies
@@ -79,14 +89,24 @@ jobs:
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
-          # Poetryの依存関係キャッシュを有効化
-          cache: "poetry"
+          # actions/setup-pythonのcacheオプションはpoetry自体をインストールしないため削除
 
       # Poetryのインストール
       - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+        run: pip install poetry
+
+      # Poetryキャッシュディレクトリの設定
+      - name: Set Poetry cache directory
+        run: echo "POETRY_CACHE_DIR=$(poetry config cache-dir)" >> $GITHUB_ENV
+
+      # Poetry依存関係キャッシュの復元
+      - name: Restore Poetry dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.POETRY_CACHE_DIR }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,11 @@ jobs:
           cache: "poetry" # poetryの依存関係をキャッシュします
 
       # Poetryをインストールします。
-      # pipx経由でPoetryをインストールし、PATHに追加します。
+      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
       - name: Install Poetry
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pipx
-          python -m pipx ensurepath
-          pipx install poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+        with:
+          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
 
       # poetryの依存関係をインストールします。
       # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
@@ -108,12 +106,11 @@ jobs:
           cache: "poetry"
 
       # Poetryをインストールします。
+      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
       - name: Install Poetry
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pipx
-          python -m pipx ensurepath
-          pipx install poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+        with:
+          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
 
       # poetryの依存関係をインストールします。
       - name: Install dependencies with Poetry
@@ -124,4 +121,4 @@ jobs:
       # pytest-covプラグインを使用してカバレッジレポートを生成します。
       - name: Run unit tests with Pytest
         run: |
-          poetry run pytest --cov=./ --cov-report=xml-
+          poetry run pytest --cov=./ --cov-report=xml


### PR DESCRIPTION
このプルリクエストでは、Pythonプロジェクトの継続的インテグレーション（CI）を行うためのGitHub Actionsワークフローを追加します。

このワークフローは、プロジェクトの依存関係をインストールし、ユニットテストを実行することで、コードの品質と安定性を自動的にチェックします。

---

### 1. ワークフロー全体の目的と概要

このワークフロー「Python CI」は、Pythonプロジェクトのコードが変更された際に、自動的に以下のことを確認するために設計されています。

*   **依存関係のインストール**: プロジェクトに必要なライブラリ（依存関係）が正しくインストールできるかを確認します。
*   **ユニットテストの実行**: プロジェクトの各機能が意図通りに動作するかを検証するユニットテストを実行します。

現在は手動で実行する設定になっていますが、将来的にコードがリポジトリにプッシュされた時や、プルリクエストが作成された時に自動で実行されるように拡張することも可能です。

---

### 2. 各ジョブ・ステップの詳細

このワークフローは、大きく分けて「`build`（ビルド）」と「`tests`（テスト実行）」の2つのジョブで構成されています。

#### 2.1. ジョブ: `build` (ビルド)

このジョブでは、テストを実行するための準備として、プロジェクトの依存関係をインストールします。

*   **ジョブ名**: `Build`
*   **実行環境**: `ubuntu-latest` (最新のUbuntu Linux環境)
*   **タイムアウト**: 10分 (10分を超えると強制終了)
*   **権限**: `contents: read` (リポジトリの内容を読み取る最小限の権限)

##### ステップ: `Checkout repository` (リポジトリのチェックアウト)

```yaml
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          persist-credentials: false
```

*   **役割・ポイント**:
    *   GitHub Actionsが実行される仮想環境に、このリポジトリのコードをダウンロード（チェックアウト）します。
    *   これにより、ワークフローがプロジェクトのファイルにアクセスできるようになります。
*   **補足説明**:
    *   `uses: actions/checkout@v4`: GitHubが提供する公式アクションで、リポジトリをチェックアウトするために使われます。`@v4`はアクションのバージョンを示します。
    *   `persist-credentials: false`: セキュリティのため、認証情報（GitHubへのログイン情報など）を永続的に保存しない設定です。

##### ステップ: `Set up Python` (Python環境のセットアップ)

```yaml
      - name: Set up Python
        uses: actions/setup-python@v5
        with:
          python-version: "3.13"
```

*   **役割・ポイント**:
    *   プロジェクトで指定されているPythonのバージョン（ここでは`3.13`）を仮想環境にセットアップします。
    *   これにより、以降のステップでPythonコマンドが正しく実行できるようになります。
*   **補足説明**:
    *   `uses: actions/setup-python@v5`: GitHubが提供する公式アクションで、特定のPythonバージョンをセットアップするために使われます。

##### ステップ: `Install Poetry` (Poetryのインストール)

```yaml
      - name: Install Poetry
        run: pip install poetry
```

*   **役割・ポイント**:
    *   Pythonの依存関係管理ツールである「Poetry」をインストールします。
    *   Poetryは、プロジェクトが必要とするライブラリ（依存関係）を管理し、仮想環境を構築するのに役立ちます。
*   **補足説明**:
    *   `pip install poetry`: Pythonのパッケージインストーラーである`pip`を使って、`poetry`パッケージをインストールするコマンドです。

##### ステップ: `Set Poetry cache directory` (Poetryキャッシュディレクトリの設定)

```yaml
      - name: Set Poetry cache directory
        run: echo "POETRY_CACHE_DIR=$(poetry config cache-dir)" >> $GITHUB_ENV
```

*   **役割・ポイント**:
    *   Poetryが依存関係をキャッシュする場所（ディレクトリ）を特定し、そのパスを`POETRY_CACHE_DIR`という環境変数に設定します。
    *   この環境変数は、次のステップでキャッシュを管理するために使われます。
*   **補足説明**:
    *   `poetry config cache-dir`: Poetryのキャッシュディレクトリのパスを表示するコマンドです。
    *   `>> $GITHUB_ENV`: コマンドの出力結果を`GITHUB_ENV`という特別なファイルに追記することで、その内容を以降のステップで環境変数として利用できるようにします。

##### ステップ: `Restore Poetry dependencies cache` (Poetry依存関係キャッシュの復元)

```yaml
      - name: Restore Poetry dependencies cache
        uses: actions/cache@v4
        with:
          path: ${{ env.POETRY_CACHE_DIR }}
          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
          restore-keys: |
            ${{ runner.os }}-poetry-
```

*   **役割・ポイント**:
    *   以前のワークフロー実行時に保存されたPoetryの依存関係キャッシュを復元します。
    *   これにより、毎回すべての依存関係をインターネットからダウンロードする手間が省け、ワークフローの実行時間を大幅に短縮できます。
*   **補足説明**:
    *   `uses: actions/cache@v4`: GitHubが提供する公式アクションで、ファイルやディレクトリをキャッシュ・復元するために使われます。
    *   `path: ${{ env.POETRY_CACHE_DIR }}`: キャッシュの対象となるディレクトリを指定します。ここでは先ほど設定した環境変数を使っています。
    *   `key: ...`: キャッシュを一意に識別するためのキーです。`runner.os`（実行環境のOS）と`poetry.lock`ファイルの内容のハッシュ値（ファイルの変更を識別する値）を組み合わせています。`poetry.lock`ファイルが変更されると、新しいキャッシュが作成されます。
    *   `restore-keys: ...`: `key`で完全に一致するキャッシュが見つからなかった場合に、より一般的なキー（例: OSとPoetryの組み合わせ）でキャッシュを検索し、復元を試みます。

##### ステップ: `Install Poetry dependencies` (Poetryの依存関係をインストール)

```yaml
      - name: Install Poetry dependencies
        run: |
          poetry config virtualenvs.create false
          poetry install --no-interaction --no-ansi
```

*   **役割・ポイント**:
    *   `poetry.lock`ファイルに記述されているプロジェクトの依存関係（必要なライブラリ）をインストールします。
    *   `virtualenvs.create false`を設定することで、Poetryが独自の仮想環境を作成せず、GitHub Actionsの実行環境に直接ライブラリをインストールします。これはCI環境では一般的な設定です。
*   **補足説明**:
    *   `poetry config virtualenvs.create false`: Poetryが仮想環境を自動作成する設定を無効にします。
    *   `poetry install`: `poetry.lock`ファイルに基づいて、プロジェクトの依存関係をインストールするコマンドです。
    *   `--no-interaction`: 対話モード（ユーザーの入力を求めるプロンプト）を無効にします。
    *   `--no-ansi`: ANSIエスケープシーケンス（色付けなど）を無効にし、ログをよりシンプルにします。

#### 2.2. ジョブ: `tests` (テスト実行)

このジョブでは、`build`ジョブで準備された環境を使って、プロジェクトのユニットテストを実行します。

*   **ジョブ名**: `Run Tests`
*   **実行条件**: `needs: build` (このジョブは`build`ジョブが成功した後にのみ実行されます)
*   **実行環境**: `ubuntu-latest`
*   **タイムアウト**: 10分
*   **権限**: `contents: read`

##### ステップ: `Checkout repository` から `Install Poetry dependencies` まで

```yaml
      # リポジトリのチェックアウト
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          # 認証情報を永続化しない (セキュリティのため)
          persist-credentials: false

      # Python環境のセットアップ
      - name: Set up Python
        uses: actions/setup-python@v5
        with:
          # プロジェクトで指定されているPythonバージョン
          python-version: "3.13"
          # actions/setup-pythonのcacheオプションはpoetry自体をインストールしないため削除

      # Poetryのインストール
      - name: Install Poetry
        run: pip install poetry

      # Poetryキャッシュディレクトリの設定
      - name: Set Poetry cache directory
        run: echo "POETRY_CACHE_DIR=$(poetry config cache-dir)" >> $GITHUB_ENV

      # Poetry依存関係キャッシュの復元
      - name: Restore Poetry dependencies cache
        uses: actions/cache@v4
        with:
          path: ${{ env.POETRY_CACHE_DIR }}
          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
          restore-keys: |
            ${{ runner.os }}-poetry-

      # Poetryの依存関係をインストール
      - name: Install Poetry dependencies
        # Poetryの仮想環境作成を無効化し、システムPythonにインストール
        run: |
          poetry config virtualenvs.create false
          poetry install --no-interaction --no-ansi
```

*   **役割・ポイント**:
    *   これらのステップは、`build`ジョブと全く同じ内容です。テストを実行するために必要な環境（リポジトリのコード、Python、Poetry、依存関係）を再度セットアップします。
*   **補足説明**:
    *   各ステップの詳細は、上記の`build`ジョブの解説をご参照ください。

##### ステップ: `Run unit tests` (ユニットテストの実行)

```yaml
      - name: Run unit tests
        # poetry run を使って、Poetryが管理する環境でコマンドを実行
        run: poetry run python -m unittest discover tests
```

*   **役割・ポイント**:
    *   Pythonの標準テストフレームワークである`unittest`を使って、プロジェクト内のユニットテストを実行します。
    *   `poetry run`を使うことで、Poetryが管理する環境（この場合はシステムPythonにインストールされた依存関係）でテストコマンドが実行されることを保証します。
*   **補足説明**:
    *   `poetry run`: Poetryの仮想環境（または設定された環境）内でコマンドを実行するためのプレフィックスです。
    *   `python -m unittest discover tests`: `unittest`モジュールを使い、`tests`ディレクトリ内にあるテストファイルを探して実行するコマンドです。

---

### 3. 注意点やよくあるミス、今後の改善点

*   **冗長なステップの繰り返し**:
    *   `build`ジョブと`tests`ジョブで、リポジトリのチェックアウトから依存関係のインストールまでのステップが完全に重複しています。これはワークフローの実行時間を長くし、メンテナンス性を低下させる可能性があります。
    *   **改善案**: GitHub Actionsの「再利用可能なワークフロー」や「ジョブの出力」機能を使うことで、これらの共通ステップを一度だけ実行し、その結果を他のジョブで利用するように改善できます。
*   **トリガー設定**:
    *   現在の設定では`workflow_dispatch`のみが有効なため、手動でしかワークフローを実行できません。
    *   **改善案**: コメントアウトされている`push`や`pull_request`イベントを有効にすることで、コードが変更された際に自動的にCIが実行されるようになります。
*   **Pythonバージョン**:
    *   `python-version: "3.13"`が指定されています。プロジェクトの`pyproject.toml`ファイルや開発環境で使われているPythonバージョンと一致しているか確認してください。
*   **Poetryの仮想環境**:
    *   `poetry config virtualenvs.create false`を設定しているため、Poetryは仮想環境を作成せず、システムPython環境に依存関係をインストールします。これはCI環境では一般的ですが、もしPoetryの仮想環境内でテストを実行したい場合は、この設定を見直す必要があります。
*   **テストコマンド**:
    *   `python -m unittest discover tests`は、`tests`という名前のディレクトリにテストファイルがあることを前提としています。プロジェクトのテストファイルの配置に合わせて、このコマンドを調整してください。
*   **静的解析ツールの追加**:
    *   コメントアウトされているように、`flake8`（コードスタイルチェック）、`black`（コードフォーマッター）、`mypy`（型チェック）などの静的解析ツールを追加することで、コード品質をさらに向上させることができます。これらのツールも`poetry run`を使って実行できます。
*   **権限設定**:
    *   `permissions: contents: read`は最小限の権限でセキュリティ上好ましいですが、もし今後、テスト結果のアーティファクト（成果物）をアップロードしたり、GitHubのAPIを操作したりする必要が生じた場合は、適切な権限を追加する必要があります。

---

このワークフローは、Pythonプロジェクトの基本的なCI基盤として機能します。上記の注意点や改善点を参考に、プロジェクトのニーズに合わせてさらに発展させていくことができます。