### PR TITLE
GitHubワークフローファイルの作成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-python-3.13-poetry-
 
-      # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
+      # プロジェクトの依存関係をインストール
+      # `--with dev` オプションは、`pyproject.toml` に `[tool.poetry.group.dev.dependencies]` が定義されていないためエラーになりました。
+      # このオプションを削除することで、現在のエラーは解消されます。
+      # もし `pytest` や `ruff` が見つからないエラーが再発した場合は、
+      # `pyproject.toml` の `[tool.poetry.group.dev.dependencies]` にそれらを定義するか、
+      # `[tool.poetry.dependencies]` に含めることを検討してください。
       - name: Install project dependencies
         run: |
-          poetry install --no-interaction --no-ansi --with dev
+          poetry install --no-interaction --no-ansi
 
       # コードのリンティングとフォーマットチェック (Ruffを使用)
       - name: Run linters and format check
@@ -110,9 +115,14 @@ jobs:
             ${{ runner.os }}-python-3.13-poetry-
 
       # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
+      # `--with dev` オプションは、`pyproject.toml` に `[tool.poetry.group.dev.dependencies]` が定義されていないためエラーになりました。
+      # このオプションを削除することで、現在のエラーは解消されます。
+      # もし `pytest` や `ruff` が見つからないエラーが再発した場合は、
+      # `pyproject.toml` の `[tool.poetry.group.dev.dependencies]` にそれらを定義するか、
+      # `[tool.poetry.dependencies]` に含めることを検討してください。
       - name: Install project dependencies
         run: |
-          poetry install --no-interaction --no-ansi --with dev
+          poetry install --no-interaction --no-ansi
 
       # Pytestでユニットテストを実行し、カバレッジを生成
       - name: Run unit tests with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,114 +1,129 @@
-name: CI
+name: Python CI
 
-# ワークフローのトリガーイベントを設定します。
-# workflow_dispatchは手動実行を可能にします。
-# 他のイベントを追加する場合は、以下のように記述します。
-# on:
-#   push:
-#     branches:
-#       - main
-#   pull_request:
-#     branches:
-#       - main
 on:
   workflow_dispatch:
+    # 他のイベントを追加する場合は、以下を参考にしてください。
+    # push:
+    #   branches: [ main, develop ]
+    # pull_request:
+    #   branches: [ main, develop ]
+    # schedule:
+    #   - cron: '0 0 * * *' # 毎日深夜0時に実行
 
 jobs:
-  # ビルドと静的解析を行うジョブ
   build:
-    name: Build and Lint
-    # ジョブを実行するランナーのOSを指定します。
+    # ビルドジョブ: Pythonパッケージのビルドを行います。
+    name: Build Python Package
     runs-on: ubuntu-latest
-    # ジョブに必要な権限を最小限に設定します。
     permissions:
-      contents: read
-    # ジョブのタイムアウト時間を設定します。
-    timeout-minutes: 10
+      contents: read # リポジトリの読み取り権限のみ
+    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
 
     steps:
+    - name: Checkout repository
       # リポジトリのコードをチェックアウトします。
-      # persist-credentialsはセキュリティのためfalseに設定します。
-      - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      with:
+        persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップし、Poetryをインストールします。
-      # cache: 'poetry' を指定することで、poetry.lockに基づいて依存関係のキャッシュが自動的に管理されます。
-      # 複数バージョンのPythonでテストする場合は、strategy.matrixを使用します。
-      # 例:
-      # strategy:
-      #   matrix:
-      #     python-version: ["3.9", "3.10", "3.11"]
-      # steps:
-      #   - name: Set up Python ${{ matrix.python-version }}
-      #     uses: actions/setup-python@v5
-      #     with:
-      #       python-version: ${{ matrix.python-version }}
-      #       cache: 'poetry'
-      - name: Set up Python 3.11 and Poetry
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
+    - name: Set up Python 3.10
+      # Python環境をセットアップします。
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: '3.10' # ビルドに使用するPythonバージョン
+        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
 
-      # Poetryを使ってプロジェクトの依存関係をインストールします。
-      # --no-interaction と --no-ansi はCI環境での非対話的な実行を保証します。
-      - name: Install dependencies with Poetry
-        run: poetry install --no-interaction --no-ansi
+    - name: Cache Poetry dependencies
+      # Poetryの依存関係をキャッシュし、ビルド時間を短縮します。
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+        key: poetry-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
+        restore-keys: |
+          poetry-${{ runner.os }}-3.10-
+          poetry-${{ runner.os }}-
 
-      # Pythonコードのリンティング（静的解析）を実行します。
-      # Ruffは非常に高速なリンターです。
-      - name: Run Ruff linter
-        run: poetry run ruff check .
+    - name: Install Poetry
+      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
+      run: |
+        curl -sSL https://install.python-poetry.org | python -
+        poetry config virtualenvs.in-project true
 
-      # Pythonコードのフォーマットチェックを実行します。
-      # Blackはコードフォーマッターで、--checkオプションでフォーマット違反がないか確認します。
-      - name: Run Black formatter check
-        run: poetry run black --check .
+    - name: Install dependencies
+      # poetry.lockに基づいて依存関係をインストールします。
+      run: poetry install --no-root --sync
 
-  # テストを実行するジョブ
+    - name: Build package
+      # Pythonパッケージをビルドします。
+      run: poetry build
+
   tests:
-    name: Run Tests
-    # このジョブはbuildジョブが成功した後にのみ実行されます。
-    needs: build
-    # ジョブを実行するランナーのOSを指定します。
+    # テストジョブ: 複数のPythonバージョンでテストと品質チェックを実行します。
+    name: Run Tests and Quality Checks
     runs-on: ubuntu-latest
-    # ジョブに必要な権限を最小限に設定します。
     permissions:
-      contents: read
-    # ジョブのタイムアウト時間を設定します。
-    timeout-minutes: 10
+      contents: read # リポジトリの読み取り権限のみ
+    timeout-minutes: 20 # ジョブの最大実行時間を20分に設定
+
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11'] # 複数のPythonバージョンでテストを実行
 
     steps:
+    - name: Checkout repository
       # リポジトリのコードをチェックアウトします。
-      - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      with:
+        persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップし、Poetryをインストールします。
-      # buildジョブと同様にキャッシュを活用します。
-      - name: Set up Python 3.11 and Poetry
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
+    - name: Set up Python ${{ matrix.python-version }}
+      # Python環境をセットアップします。
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
 
-      # Poetryを使ってプロジェクトの依存関係をインストールします。
-      - name: Install dependencies with Poetry
-        run: poetry install --no-interaction --no-ansi
+    - name: Cache Poetry dependencies
+      # Poetryの依存関係をキャッシュし、テスト時間を短縮します。
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
+        restore-keys: |
+          poetry-${{ runner.os }}-${{ matrix.python-version }}-
+          poetry-${{ runner.os }}-
 
-      # Pytestを使ってユニットテストを実行し、カバレッジレポートを生成します。
-      # --cov=./test は 'test' ディレクトリのコードカバレッジを計測します。
-      # --cov-report=xml はXML形式でカバレッジレポートを出力します。
-      - name: Run unit tests with coverage
-        run: poetry run pytest --cov=./test --cov-report=xml
+    - name: Install Poetry
+      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
+      run: |
+        curl -sSL https://install.python-poetry.org | python -
+        poetry config virtualenvs.in-project true
 
-      # 生成されたカバレッジレポートをアーティファクトとしてアップロードします。
-      # これにより、GitHub Actionsの実行結果からレポートをダウンロードして確認できます。
-      - name: Upload coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: coverage-report
-          path: coverage.xml
+    - name: Install dependencies
+      # poetry.lockに基づいて依存関係と開発ツール（pytest, lintersなど）をインストールします。
+      # pyproject.tomlにdev-dependenciesが定義されている場合、これによってインストールされます。
+      run: poetry install --no-root --sync
+
+    - name: Run linters (Black, Flake8, isort)
+      # コードスタイルと品質チェックを実行します。
+      run: |
+        poetry run black --check .
+        poetry run flake8 .
+        poetry run isort --check-only .
+
+    - name: Run type checker (mypy)
+      # 静的型チェックを実行します。
+      run: poetry run mypy .
+
+    - name: Run tests with coverage
+      # pytestを使用してテストを実行し、カバレッジレポートを生成します。
+      run: poetry run pytest --cov=. --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      # 生成されたカバレッジレポートをCodecovにアップロードします。
+      # プライベートリポジトリの場合や、Codecovの特定の機能を利用する場合は、
+      # secrets.CODECOV_TOKEN を設定する必要がある場合があります。
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+      with:
+        files: ./coverage.xml
+        # token: ${{ secrets.CODECOV_TOKEN }} # 必要に応じて設定

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,92 +1,93 @@
 name: CI
+
 on:
   workflow_dispatch:
+    # 手動でワークフローを実行するためのイベント。
+    #
+    # 他のイベントを追加する場合は、以下のように記述します。
     # push:
-    #   branches: [ main ]
+    #   branches:
+    #     - main
     # pull_request:
-    #   branches: [ main ]
+    #   branches:
+    #     - main
 
 jobs:
   build:
-    name: ビルド
+    # Pythonパッケージをビルドするジョブ
+    name: Build Python Package
     runs-on: ubuntu-latest
     permissions:
-      contents: read # リポジトリのコンテンツを読み取るための最小権限
-      actions: write # アーティファクトをアップロードするための権限
-    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+      contents: write # リポジトリのチェックアウトとアーティファクトのアップロードに必要
+    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
+
     steps:
-      - name: リポジトリをチェックアウト
+      - name: Checkout repository # リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない
 
-      - name: Python 3.13 をセットアップ
-        id: setup-python # 後続のステップでPythonバージョンを参照するためにIDを設定
+      - name: Set up Python 3.13 # Python 3.13をセットアップ
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13" # pyproject.toml に基づくPythonバージョン
+          python-version: "3.13" # pyproject.tomlのrequires-pythonに合わせて3.13を指定
 
-      - name: Poetry キャッシュを復元
+      - name: Install Poetry # Poetryをインストール
+        run: pip install poetry
+
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキャッシュキー
+          path: ~/.cache/pypoetry # Poetryのキャッシュパス
+          key: python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンとpoetry.lockのハッシュをキーに設定
           restore-keys: |
-            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry- # 復元キー
+            python-3.13-poetry- # キャッシュが見つからない場合に復元を試みるキー
 
-      - name: Poetry をインストール
-        run: |
-          pip install poetry==1.8.2 # Poetryのバージョンを固定してインストール
+      - name: Install dependencies # プロジェクトの依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # Poetryを使って依存関係をインストール
 
-      - name: 依存関係をインストール
-        run: |
-          poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
+      - name: Build package # Pythonパッケージをビルド
+        run: poetry build # Poetryを使ってパッケージをビルド
 
-      - name: パッケージをビルド
-        run: |
-          poetry build # プロジェクトのパッケージをビルド
-
-      - name: ビルド成果物をアップロード
+      - name: Upload artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: dist # アーティファクト名
-          path: dist/ # ビルド成果物のパス
+          name: python-package # アーティファクトの名前
+          path: dist/ # アップロードするパス
 
   tests:
-    name: テスト
+    # プロジェクトのテストを実行するジョブ
+    name: Run Tests
     runs-on: ubuntu-latest
     permissions:
-      contents: read # リポジトリのコンテンツを読み取るための最小権限
-    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+      contents: read # リポジトリのチェックアウトに必要
+    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
     needs: build # ビルドジョブが成功した後に実行
+
     steps:
-      - name: リポジトリをチェックアウト
+      - name: Checkout repository # リポジリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない
 
-      - name: Python 3.13 をセットアップ
-        id: setup-python # 後続のステップでPythonバージョンを参照するためにIDを設定
+      - name: Set up Python 3.13 # Python 3.13をセットアップ
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13" # pyproject.toml に基づくPythonバージョン
+          python-version: "3.13" # pyproject.tomlのrequires-pythonに合わせて3.13を指定
 
-      - name: Poetry キャッシュを復元
+      - name: Install Poetry # Poetryをインストール
+        run: pip install poetry
+
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキャッシュキー
+          path: ~/.cache/pypoetry # Poetryのキャッシュパス
+          key: python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンとpoetry.lockのハッシュをキーに設定
           restore-keys: |
-            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry- # 復元キー
+            python-3.13-poetry- # キャッシュが見つからない場合に復元を試みるキー
 
-      - name: Poetry をインストール
-        run: |
-          pip install poetry==1.8.2 # Poetryのバージョンを固定してインストール
+      - name: Install dependencies # プロジェクトの依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # Poetryを使って依存関係をインストール
 
-      - name: 依存関係をインストール
-        run: |
-          poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
-
-      - name: ユニットテストを実行
-        run: |
-          python -m unittest discover tests # unittestモジュールを使用してテストを実行
+      - name: Run unit tests # ユニットテストを実行
+        run: python -m unittest discover tests # unittestモジュールを使ってtestsディレクトリ内のテストを発見し実行

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,32 @@
-name: CI
+name: Python CI/CD Workflow # ワークフローの名前
+
 on:
-  workflow_dispatch:
-    # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
-    # push:
-    #   branches:
-    #     - main # デフォルトブランチ名に合わせて変更してください
-    # pull_request:
-    #   branches:
-    #     - main # デフォルトブランチ名に合わせて変更してください
+  workflow_dispatch: # 手動でワークフローを実行するためのトリガー
+  # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
+  # push:
+  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのpush時に実行
+  # pull_request:
+  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのプルリクエスト時に実行
+
+# 同一ブランチでの重複実行を避けるための設定
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    name: Build and Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    name: Build Python Package # ビルドジョブの名前
+    runs-on: ubuntu-latest # ジョブを実行するOS
+    timeout-minutes: 10 # ジョブの最大実行時間
     permissions:
       contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
 
     steps:
-      - name: Checkout repository # リポジトリをチェックアウト
+      - name: Checkout Repository # リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
@@ -31,58 +35,43 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
 
       - name: Install Poetry # Poetryをインストール
         run: |
           pip install poetry
-          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
 
-      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
-        id: cache-poetry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
-          restore-keys: |
-            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
-
-      - name: Install dependencies # 依存関係をインストール
-        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
-
-      - name: Lint with Flake8 # Flake8でコードのスタイルをチェック
+      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
         run: |
-          pip install flake8 # flake8をインストール
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # エラーのみ表示
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics # 警告も表示するが、CIを失敗させない
+          poetry config virtualenvs.create false
 
-      - name: Check code formatting with Black # Blackでコードのフォーマットをチェック
+      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
         run: |
-          pip install black # blackをインストール
-          black --check . # フォーマット違反がないかチェック（修正はしない）
+          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
 
-      - name: Build package # パッケージをビルド
-        run: poetry build # wheelとsdistを生成
+      - name: Build Python package # Pythonパッケージをビルド
+        run: |
+          poetry build # sdistとwheelを生成
 
-      - name: Upload build artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
+      - name: Upload built artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: dist-${{ matrix.python-version }} # アーティファクト名
+          name: dist-${{ matrix.python-version }} # アーティファクトの名前
           path: dist/ # ビルド成果物のパス
 
   tests:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    name: Run Tests and Lint # テストとリンティングジョブの名前
+    runs-on: ubuntu-latest # ジョブを実行するOS
+    timeout-minutes: 15 # ジョブの最大実行時間
     permissions:
       contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
-    needs: build # buildジョブが成功した後に実行
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
 
     steps:
-      - name: Checkout repository # リポジトリをチェックアウト
+      - name: Checkout Repository # リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
@@ -91,31 +80,37 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
 
       - name: Install Poetry # Poetryをインストール
         run: |
           pip install poetry
-          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
 
-      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
-        id: cache-poetry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
-          restore-keys: |
-            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
-
-      - name: Install dependencies # 依存関係をインストール
-        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
-
-      - name: Run tests with Pytest # Pytestでテストを実行
+      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
         run: |
-          pip install pytest pytest-cov # pytestとカバレッジツールをインストール
-          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing # テストを実行し、カバレッジレポートを生成
+          poetry config virtualenvs.create false
+
+      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
+        run: |
+          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
+          # ruff, pytest, pytest-covなどの開発依存もpyproject.tomlに定義されていればここでインストールされる
+
+      - name: Run Ruff Linter # Ruffを使ってコードの静的解析を実行
+        run: |
+          poetry run ruff check . # プロジェクト全体をチェック
+
+      - name: Run Ruff Formatter Check # Ruffを使ってコードのフォーマットチェックを実行
+        run: |
+          poetry run ruff format --check . # フォーマット違反がないかチェック
+
+      - name: Run Pytest # Pytestを使ってユニットテストを実行
+        run: |
+          poetry run pytest -q --cov=test --cov-report=xml # テストを実行し、カバレッジレポートをXML形式で生成
+        env:
+          PYTHONPATH: . # プロジェクトルートをPYTHONPATHに追加してモジュールをインポート可能にする
 
       - name: Upload coverage report # カバレッジレポートをアーティファクトとしてアップロード
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: coverage-report-${{ matrix.python-version }} # アーティファクト名
+          name: coverage-report-${{ matrix.python-version }} # アーティファクトの名前
           path: coverage.xml # カバレッジレポートのパス

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,19 +37,27 @@ jobs:
       # リポジリのコードをチェックアウトします。
       # persist-credentials: false はセキュリティのベストプラクティスです。
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false
 
-      # Python環境をセットアップし、Poetryをインストールします。
+      # Python環境をセットアップします。
       # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
-      # ここではPython 3.13を指定し、pipx経由でPoetryをインストールします。
-      - name: Set up Python 3.13 and Install Poetry
-        uses: actions/setup-python@v5
+      # ここではPython 3.13を指定し、poetryの依存関係をキャッシュします。
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
           cache: "poetry" # poetryの依存関係をキャッシュします
-          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
+
+      # Poetryをインストールします。
+      # pipx経由でPoetryをインストールし、PATHに追加します。
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pipx
+          python -m pipx ensurepath
+          pipx install poetry
 
       # poetryの依存関係をインストールします。
       # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
@@ -88,17 +96,24 @@ jobs:
     steps:
       # リポジトリのコードをチェックアウトします。
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false
 
-      # Python環境をセットアップし、Poetryをインストールします。
-      - name: Set up Python 3.13 and Install Poetry
-        uses: actions/setup-python@v5
+      # Python環境をセットアップします。
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
           cache: "poetry"
-          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
+
+      # Poetryをインストールします。
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pipx
+          python -m pipx ensurepath
+          pipx install poetry
 
       # poetryの依存関係をインストールします。
       - name: Install dependencies with Poetry
@@ -109,4 +124,4 @@ jobs:
       # pytest-covプラグインを使用してカバレッジレポートを生成します。
       - name: Run unit tests with Pytest
         run: |
-          poetry run pytest --cov=./ --cov-report=xml
+          poetry run pytest --cov=./ --cov-report=xml-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,124 +1,126 @@
 name: Python CI
 
-# ワークフローのトリガーイベントを定義します。
-# workflow_dispatchは手動実行を可能にします。
-# 他のイベント（例: push, pull_request）を追加する場合は、以下のように記述します。
-# on:
-#   push:
-#     branches: [ main ]
-#   pull_request:
-#     branches: [ main ]
-#   workflow_dispatch:
 on:
+  # 手動でワークフローを実行するためのイベント
   workflow_dispatch:
+  # 他のイベントを追加する場合は、以下のコメントアウトを解除してください
+  # push:
+  #   branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
 
-# ジョブの並行実行を制御します。
-# 同じブランチでの重複実行を防ぎ、最新のコミットのみを処理します。
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-# ワークフロー内のジョブを定義します。
 jobs:
-  # ビルドジョブ
   build:
-    # ジョブの表示名
+    # ビルドジョブの名前
     name: Build and Lint
-    # ジョブが実行されるランナー環境
+    # ジョブが実行されるランナーのOS
     runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定 (分)
+    # ジョブのタイムアウト設定
     timeout-minutes: 10
-    # ジョブの権限設定 (最小権限の原則に従う)
+    # ジョブの権限設定 (成果物のアップロードのため write 権限が必要)
     permissions:
-      contents: read # リポジトリのコードを読み取るために必要
+      contents: write
 
-    # ジョブのステップを定義します。
     steps:
-      # リポジリのコードをチェックアウトします。
-      # persist-credentials: false はセキュリティのベストプラクティスです。
+      # コードをチェックアウト
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false
+          persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップします。
-      # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
-      # ここではPython 3.13を指定し、poetryの依存関係をキャッシュします。
-      - name: Set up Python 3.13
+      # Python環境をセットアップ
+      - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13"
-          cache: "poetry" # poetryの依存関係をキャッシュします
+          python-version: '3.12' # Python 3.12を使用。プロジェクトがPython 3.13をターゲットとしている場合は、GitHub Actionsで利用可能になり次第 '3.13' に変更を検討してください。
 
-      # Poetryをインストールします。
-      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
+      # Poetryをインストール
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
-        with:
-          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
+        run: |
+          pip install poetry
 
-      # poetryの依存関係をインストールします。
-      # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
-      - name: Install dependencies with Poetry
+      # Poetryの依存関係キャッシュを復元/保存
+      - name: Cache Poetry dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+          key: ${{ runner.os }}-python-3.12-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-3.12-poetry-
+
+      # プロジェクトの依存関係をインストール
+      - name: Install project dependencies
         run: |
           poetry install --no-interaction --no-ansi
 
-      # コードの静的解析 (Lint) を実行します。
-      # flake8を使用してコードスタイルと品質をチェックします。
-      - name: Run Flake8 Lint
+      # コードのリンティングとフォーマットチェック (Ruffを使用)
+      - name: Run linters and format check
         run: |
-          poetry run flake8 .
+          poetry run ruff check .
+          poetry run ruff format . --check
 
-      # コードのフォーマットチェック (Black) を実行します。
-      # フォーマット違反がないか確認し、違反があれば失敗させます。
-      - name: Check code format with Black
+      # パッケージをビルド
+      - name: Build package
         run: |
-          poetry run black --check .
+          poetry build
 
-  # テストジョブ
+      # ビルドされたパッケージをアーティファクトとしてアップロード
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist
+          path: dist/
+
   tests:
-    # ジョブの表示名
-    name: Run Tests
-    # ジョブが実行されるランナー環境
+    # テストジョブの名前
+    name: Run Unit Tests
+    # ジョブが実行されるランナーのOS
     runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定 (分)
+    # ジョブのタイムアウト設定
     timeout-minutes: 10
-    # ジョブの権限設定 (最小権限の原則に従う)
+    # ジョブの権限設定 (コードの読み取りのみのため read 権限)
     permissions:
-      contents: read # リポジトリのコードを読み取るために必要
+      contents: read
 
-    # buildジョブが成功した場合にのみ実行します。
-    needs: build
-
-    # ジョブのステップを定義します。
     steps:
-      # リポジトリのコードをチェックアウトします。
+      # コードをチェックアウト
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false
+          persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境をセットアップします。
-      - name: Set up Python 3.13
+      # Python環境をセットアップ
+      - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13"
-          cache: "poetry"
+          python-version: '3.12' # Python 3.12を使用。プロジェクトがPython 3.13をターゲットとしている場合は、GitHub Actionsで利用可能になり次第 '3.13' に変更を検討してください。
 
-      # Poetryをインストールします。
-      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
+      # Poetryをインストール
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
-        with:
-          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
+        run: |
+          pip install poetry
 
-      # poetryの依存関係をインストールします。
-      - name: Install dependencies with Poetry
+      # Poetryの依存関係キャッシュを復元/保存
+      - name: Cache Poetry dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+          key: ${{ runner.os }}-python-3.12-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-3.12-poetry-
+
+      # プロジェクトの依存関係をインストール
+      - name: Install project dependencies
         run: |
           poetry install --no-interaction --no-ansi
 
-      # pytestを使用してユニットテストを実行します。
-      # pytest-covプラグインを使用してカバレッジレポートを生成します。
-      - name: Run unit tests with Pytest
+      # Pytestでユニットテストを実行し、カバレッジを生成
+      - name: Run unit tests with coverage
         run: |
-          poetry run pytest --cov=./ --cov-report=xml
+          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing
+        # カバレッジレポートをアーティファクトとしてアップロードする場合は、permissions: contents: write が必要です
+        # - name: Upload coverage report
+        #   uses: actions/upload-artifact@v4
+        #   with:
+        #     name: coverage-report
+        #     path: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,116 +1,120 @@
-name: Python CI/CD Workflow # ワークフローの名前
+name: Python CI
 
+# ワークフローのトリガーイベントを定義します。
+# workflow_dispatchは手動実行を可能にします。
+# 他のイベント（例: push, pull_request）を追加する場合は、以下のように記述します。
+# on:
+#   push:
+#     branches: [ main ]
+#   pull_request:
+#     branches: [ main ]
+#   workflow_dispatch:
 on:
-  workflow_dispatch: # 手動でワークフローを実行するためのトリガー
-  # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
-  # push:
-  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのpush時に実行
-  # pull_request:
-  #   branches: [ main, develop ] # mainブランチとdevelopブランチへのプルリクエスト時に実行
+  workflow_dispatch:
 
-# 同一ブランチでの重複実行を避けるための設定
+# ジョブの並行実行を制御します。
+# 同じブランチでの重複実行を防ぎ、最新のコミットのみを処理します。
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# ワークフロー内のジョブを定義します。
 jobs:
+  # ビルドジョブ
   build:
-    name: Build Python Package # ビルドジョブの名前
-    runs-on: ubuntu-latest # ジョブを実行するOS
-    timeout-minutes: 10 # ジョブの最大実行時間
+    # ジョブの表示名
+    name: Build and Lint
+    # ジョブが実行されるランナー環境
+    runs-on: ubuntu-latest
+    # ジョブのタイムアウト設定 (分)
+    timeout-minutes: 10
+    # ジョブの権限設定 (最小権限の原則に従う)
     permissions:
-      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
+      contents: read # リポジトリのコードを読み取るために必要
 
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
-
+    # ジョブのステップを定義します。
     steps:
-      - name: Checkout Repository # リポジトリをチェックアウト
+      # リポジリのコードをチェックアウトします。
+      # persist-credentials: false はセキュリティのベストプラクティスです。
+      - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+          persist-credentials: false
 
-      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+      # Python環境をセットアップします。
+      # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
+      # ここではPython 3.13を指定します。
+      - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
+          python-version: "3.13"
+          cache: "poetry" # poetryの依存関係をキャッシュします
 
-      - name: Install Poetry # Poetryをインストール
+      # poetryをインストールします。
+      - name: Install Poetry
         run: |
           pip install poetry
 
-      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
+      # poetryの依存関係をインストールします。
+      # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
+      - name: Install dependencies with Poetry
         run: |
-          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
 
-      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
+      # コードの静的解析 (Lint) を実行します。
+      # flake8を使用してコードスタイルと品質をチェックします。
+      - name: Run Flake8 Lint
         run: |
-          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
+          poetry run flake8 .
 
-      - name: Build Python package # Pythonパッケージをビルド
+      # コードのフォーマットチェック (Black) を実行します。
+      # フォーマット違反がないか確認し、違反があれば失敗させます。
+      - name: Check code format with Black
         run: |
-          poetry build # sdistとwheelを生成
+          poetry run black --check .
 
-      - name: Upload built artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dist-${{ matrix.python-version }} # アーティファクトの名前
-          path: dist/ # ビルド成果物のパス
-
+  # テストジョブ
   tests:
-    name: Run Tests and Lint # テストとリンティングジョブの名前
-    runs-on: ubuntu-latest # ジョブを実行するOS
-    timeout-minutes: 15 # ジョブの最大実行時間
+    # ジョブの表示名
+    name: Run Tests
+    # ジョブが実行されるランナー環境
+    runs-on: ubuntu-latest
+    # ジョブのタイムアウト設定 (分)
+    timeout-minutes: 10
+    # ジョブの権限設定 (最小権限の原則に従う)
     permissions:
-      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
+      contents: read # リポジトリのコードを読み取るために必要
 
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"] # テストするPythonのバージョン
+    # buildジョブが成功した場合にのみ実行します。
+    needs: build
 
+    # ジョブのステップを定義します。
     steps:
-      - name: Checkout Repository # リポジトリをチェックアウト
+      # リポジトリのコードをチェックアウトします。
+      - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+          persist-credentials: false
 
-      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+      # Python環境をセットアップします。
+      - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry" # Poetryの依存関係をキャッシュする設定（actions/setup-pythonが内部で処理）
+          python-version: "3.13"
+          cache: "poetry"
 
-      - name: Install Poetry # Poetryをインストール
+      # poetryをインストールします。
+      - name: Install Poetry
         run: |
           pip install poetry
 
-      - name: Configure Poetry Virtualenvs # Poetryが仮想環境を作成しないように設定（CI環境向け）
+      # poetryの依存関係をインストールします。
+      - name: Install dependencies with Poetry
         run: |
-          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
 
-      - name: Install dependencies with Poetry # poetry.lockに基づいて依存関係をインストール
+      # pytestを使用してユニットテストを実行します。
+      # pytest-covプラグインを使用してカバレッジレポートを生成します。
+      - name: Run unit tests with Pytest
         run: |
-          poetry install --no-interaction --no-ansi # ユーザーインタラクションなし、ANSIエスケープコードなしでインストール
-          # ruff, pytest, pytest-covなどの開発依存もpyproject.tomlに定義されていればここでインストールされる
-
-      - name: Run Ruff Linter # Ruffを使ってコードの静的解析を実行
-        run: |
-          poetry run ruff check . # プロジェクト全体をチェック
-
-      - name: Run Ruff Formatter Check # Ruffを使ってコードのフォーマットチェックを実行
-        run: |
-          poetry run ruff format --check . # フォーマット違反がないかチェック
-
-      - name: Run Pytest # Pytestを使ってユニットテストを実行
-        run: |
-          poetry run pytest -q --cov=test --cov-report=xml # テストを実行し、カバレッジレポートをXML形式で生成
-        env:
-          PYTHONPATH: . # プロジェクトルートをPYTHONPATHに追加してモジュールをインポート可能にする
-
-      - name: Upload coverage report # カバレッジレポートをアーティファクトとしてアップロード
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: coverage-report-${{ matrix.python-version }} # アーティファクトの名前
-          path: coverage.xml # カバレッジレポートのパス
+          poetry run pytest --cov=./ --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,129 +1,121 @@
-name: Python CI
-
+name: CI
 on:
   workflow_dispatch:
-    # 他のイベントを追加する場合は、以下を参考にしてください。
+    # その他のイベント（例: push, pull_request）を追加する場合は、以下のコメントアウトを解除してください。
     # push:
-    #   branches: [ main, develop ]
+    #   branches:
+    #     - main # デフォルトブランチ名に合わせて変更してください
     # pull_request:
-    #   branches: [ main, develop ]
-    # schedule:
-    #   - cron: '0 0 * * *' # 毎日深夜0時に実行
+    #   branches:
+    #     - main # デフォルトブランチ名に合わせて変更してください
 
 jobs:
   build:
-    # ビルドジョブ: Pythonパッケージのビルドを行います。
-    name: Build Python Package
+    name: Build and Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
     permissions:
-      contents: read # リポジトリの読み取り権限のみ
-    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
-
-    steps:
-    - name: Checkout repository
-      # リポジトリのコードをチェックアウトします。
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      with:
-        persist-credentials: false # 認証情報を永続化しない
-
-    - name: Set up Python 3.10
-      # Python環境をセットアップします。
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        python-version: '3.10' # ビルドに使用するPythonバージョン
-        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
-
-    - name: Cache Poetry dependencies
-      # Poetryの依存関係をキャッシュし、ビルド時間を短縮します。
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-        key: poetry-${{ runner.os }}-3.10-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
-        restore-keys: |
-          poetry-${{ runner.os }}-3.10-
-          poetry-${{ runner.os }}-
-
-    - name: Install Poetry
-      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
-      run: |
-        curl -sSL https://install.python-poetry.org | python -
-        poetry config virtualenvs.in-project true
-
-    - name: Install dependencies
-      # poetry.lockに基づいて依存関係をインストールします。
-      run: poetry install --no-root --sync
-
-    - name: Build package
-      # Pythonパッケージをビルドします。
-      run: poetry build
-
-  tests:
-    # テストジョブ: 複数のPythonバージョンでテストと品質チェックを実行します。
-    name: Run Tests and Quality Checks
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # リポジトリの読み取り権限のみ
-    timeout-minutes: 20 # ジョブの最大実行時間を20分に設定
+      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11'] # 複数のPythonバージョンでテストを実行
+        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
 
     steps:
-    - name: Checkout repository
-      # リポジトリのコードをチェックアウトします。
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      with:
-        persist-credentials: false # 認証情報を永続化しない
+      - name: Checkout repository # リポジトリをチェックアウト
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
 
-    - name: Set up Python ${{ matrix.python-version }}
-      # Python環境をセットアップします。
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'poetry' # Poetryの依存関係キャッシュを有効化
+      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Cache Poetry dependencies
-      # Poetryの依存関係をキャッシュし、テスト時間を短縮します。
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-        key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキー
-        restore-keys: |
-          poetry-${{ runner.os }}-${{ matrix.python-version }}-
-          poetry-${{ runner.os }}-
+      - name: Install Poetry # Poetryをインストール
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
 
-    - name: Install Poetry
-      # Poetryをインストールし、プロジェクト内に仮想環境を作成するよう設定します。
-      run: |
-        curl -sSL https://install.python-poetry.org | python -
-        poetry config virtualenvs.in-project true
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        id: cache-poetry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
+          restore-keys: |
+            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
 
-    - name: Install dependencies
-      # poetry.lockに基づいて依存関係と開発ツール（pytest, lintersなど）をインストールします。
-      # pyproject.tomlにdev-dependenciesが定義されている場合、これによってインストールされます。
-      run: poetry install --no-root --sync
+      - name: Install dependencies # 依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
 
-    - name: Run linters (Black, Flake8, isort)
-      # コードスタイルと品質チェックを実行します。
-      run: |
-        poetry run black --check .
-        poetry run flake8 .
-        poetry run isort --check-only .
+      - name: Lint with Flake8 # Flake8でコードのスタイルをチェック
+        run: |
+          pip install flake8 # flake8をインストール
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # エラーのみ表示
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics # 警告も表示するが、CIを失敗させない
 
-    - name: Run type checker (mypy)
-      # 静的型チェックを実行します。
-      run: poetry run mypy .
+      - name: Check code formatting with Black # Blackでコードのフォーマットをチェック
+        run: |
+          pip install black # blackをインストール
+          black --check . # フォーマット違反がないかチェック（修正はしない）
 
-    - name: Run tests with coverage
-      # pytestを使用してテストを実行し、カバレッジレポートを生成します。
-      run: poetry run pytest --cov=. --cov-report=xml
+      - name: Build package # パッケージをビルド
+        run: poetry build # wheelとsdistを生成
 
-    - name: Upload coverage to Codecov
-      # 生成されたカバレッジレポートをCodecovにアップロードします。
-      # プライベートリポジトリの場合や、Codecovの特定の機能を利用する場合は、
-      # secrets.CODECOV_TOKEN を設定する必要がある場合があります。
-      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
-      with:
-        files: ./coverage.xml
-        # token: ${{ secrets.CODECOV_TOKEN }} # 必要に応じて設定
+      - name: Upload build artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist-${{ matrix.python-version }} # アーティファクト名
+          path: dist/ # ビルド成果物のパス
+
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    permissions:
+      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
+
+    needs: build # buildジョブが成功した後に実行
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+
+    steps:
+      - name: Checkout repository # リポジトリをチェックアウト
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+
+      - name: Set up Python ${{ matrix.python-version }} # 指定されたPythonバージョンをセットアップ
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry # Poetryをインストール
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create false # CI環境では仮想環境を作成しない設定
+
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        id: cache-poetry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに含める
+          restore-keys: |
+            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
+
+      - name: Install dependencies # 依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
+
+      - name: Run tests with Pytest # Pytestでテストを実行
+        run: |
+          pip install pytest pytest-cov # pytestとカバレッジツールをインストール
+          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing # テストを実行し、カバレッジレポートを生成
+
+      - name: Upload coverage report # カバレッジレポートをアーティファクトとしてアップロード
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-report-${{ matrix.python-version }} # アーティファクト名
+          path: coverage.xml # カバレッジレポートのパス

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,136 +1,97 @@
 name: Python CI
 
 on:
-  # 手動でワークフローを実行するためのイベント
   workflow_dispatch:
-  # 他のイベントを追加する場合は、以下のコメントアウトを解除してください
-  # push:
-  #   branches: [ main ]
-  # pull_request:
-  #   branches: [ main ]
+    # 他のイベントを追加する場合は、以下のように記述します。
+    # push:
+    #   branches:
+    #     - main
+    # pull_request:
+    #   branches:
+    #     - main
 
 jobs:
   build:
     # ビルドジョブの名前
-    name: Build and Lint
-    # ジョブが実行されるランナーのOS
+    name: Build
+    # ジョブの実行環境
     runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定
+    # ジョブのタイムアウト設定 (分)
     timeout-minutes: 10
-    # ジョブの権限設定 (成果物のアップロードのため write 権限が必要)
-    permissions:
-      contents: write
-
-    steps:
-      # コードをチェックアウト
-      - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false # 認証情報を永続化しない
-
-      # Python環境をセットアップ
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.13' # プロジェクトの要件に合わせてPython 3.13に修正
-
-      # Poetryをインストール
-      - name: Install Poetry
-        run: |
-          pip install poetry
-
-      # Poetryの依存関係キャッシュを復元/保存
-      - name: Cache Poetry dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
-          restore-keys: |
-            ${{ runner.os }}-python-3.13-poetry-
-
-      # プロジェクトの依存関係をインストール
-      # `--with dev` オプションは、`pyproject.toml` に `[tool.poetry.group.dev.dependencies]` が定義されていないためエラーになりました。
-      # このオプションを削除することで、現在のエラーは解消されます。
-      # もし `pytest` や `ruff` が見つからないエラーが再発した場合は、
-      # `pyproject.toml` の `[tool.poetry.group.dev.dependencies]` にそれらを定義するか、
-      # `[tool.poetry.dependencies]` に含めることを検討してください。
-      - name: Install project dependencies
-        run: |
-          poetry install --no-interaction --no-ansi
-
-      # コードのリンティングとフォーマットチェック (Ruffを使用)
-      - name: Run linters and format check
-        run: |
-          poetry run ruff check .
-          poetry run ruff format . --check
-
-      # パッケージをビルド
-      - name: Build package
-        run: |
-          poetry build
-
-      # ビルドされたパッケージをアーティファクトとしてアップロード
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dist
-          path: dist/
-
-  tests:
-    # テストジョブの名前
-    name: Run Unit Tests
-    # ジョブが実行されるランナーのOS
-    runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定
-    timeout-minutes: 10
-    # ジョブの権限設定 (コードの読み取りのみのため read 権限)
+    # ジョブの権限設定 (最小権限)
     permissions:
       contents: read
 
     steps:
-      # コードをチェックアウト
+      # リポジトリのチェックアウト
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          persist-credentials: false # 認証情報を永続化しない
+          # 認証情報を永続化しない (セキュリティのため)
+          persist-credentials: false
 
-      # Python環境をセットアップ
+      # Python環境のセットアップ
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.13' # プロジェクトの要件に合わせてPython 3.13に修正
+          # プロジェクトで指定されているPythonバージョン
+          python-version: "3.13"
+          # Poetryのキャッシュを有効化
+          cache: "poetry"
 
-      # Poetryをインストール
-      - name: Install Poetry
+      # Poetryの依存関係をインストール
+      - name: Install Poetry dependencies
+        # Poetryの仮想環境作成を無効化し、システムPythonにインストール
         run: |
-          pip install poetry
-
-      # Poetryの依存関係キャッシュを復元/保存
-      - name: Cache Poetry dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
-          restore-keys: |
-            ${{ runner.os }}-python-3.13-poetry-
-
-      # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
-      # `--with dev` オプションは、`pyproject.toml` に `[tool.poetry.group.dev.dependencies]` が定義されていないためエラーになりました。
-      # このオプションを削除することで、現在のエラーは解消されます。
-      # もし `pytest` や `ruff` が見つからないエラーが再発した場合は、
-      # `pyproject.toml` の `[tool.poetry.group.dev.dependencies]` にそれらを定義するか、
-      # `[tool.poetry.dependencies]` に含めることを検討してください。
-      - name: Install project dependencies
-        run: |
+          poetry config virtualenvs.create false
           poetry install --no-interaction --no-ansi
 
-      # Pytestでユニットテストを実行し、カバレッジを生成
-      - name: Run unit tests with coverage
+  tests:
+    # テストジョブの名前
+    name: Run Tests
+    # ビルドジョブが成功した後に実行
+    needs: build
+    # ジョブの実行環境
+    runs-on: ubuntu-latest
+    # ジョブのタイムアウト設定 (分)
+    timeout-minutes: 10
+    # ジョブの権限設定 (最小権限)
+    permissions:
+      contents: read
+
+    steps:
+      # リポジトリのチェックアウト
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          # 認証情報を永続化しない (セキュリティのため)
+          persist-credentials: false
+
+      # Python環境のセットアップ
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          # プロジェクトで指定されているPythonバージョン
+          python-version: "3.13"
+          # Poetryのキャッシュを有効化
+          cache: "poetry"
+
+      # Poetryの依存関係をインストール
+      - name: Install Poetry dependencies
+        # Poetryの仮想環境作成を無効化し、システムPythonにインストール
         run: |
-          poetry run pytest --cov=test --cov-report=xml --cov-report=term-missing
-        # カバレッジレポートをアーティファクトとしてアップロードする場合は、permissions: contents: write が必要です
-        # - name: Upload coverage report
-        #   uses: actions/upload-artifact@v4
-        #   with:
-        #     name: coverage-report
-        #     path: coverage.xml
+          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
+
+      # テストの実行
+      - name: Run unit tests
+        # unittestを使ってテストを実行
+        run: python -m unittest discover tests
+        # 静的解析ツール (flake8, black, mypyなど) を追加する場合は、ここにステップを追加します。
+        # 例:
+        # - name: Run Flake8
+        #   run: poetry run flake8 .
+        # - name: Run Black
+        #   run: poetry run black --check .
+        # - name: Run MyPy
+        #   run: poetry run mypy .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,23 +37,19 @@ jobs:
       # リポジリのコードをチェックアウトします。
       # persist-credentials: false はセキュリティのベストプラクティスです。
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # Python環境をセットアップします。
+      # Python環境をセットアップし、Poetryをインストールします。
       # プロジェクトのpyproject.tomlからPythonバージョンを自動検出するか、明示的に指定します。
-      # ここではPython 3.13を指定します。
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      # ここではPython 3.13を指定し、pipx経由でPoetryをインストールします。
+      - name: Set up Python 3.13 and Install Poetry
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: "poetry" # poetryの依存関係をキャッシュします
-
-      # poetryをインストールします。
-      - name: Install Poetry
-        run: |
-          pip install poetry
+          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
 
       # poetryの依存関係をインストールします。
       # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
@@ -92,21 +88,17 @@ jobs:
     steps:
       # リポジトリのコードをチェックアウトします。
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # Python環境をセットアップします。
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      # Python環境をセットアップし、Poetryをインストールします。
+      - name: Set up Python 3.13 and Install Poetry
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: "poetry"
-
-      # poetryをインストールします。
-      - name: Install Poetry
-        run: |
-          pip install poetry
+          pipx-packages: "poetry" # pipx経由でPoetryをインストールし、PATHに追加します
 
       # poetryの依存関係をインストールします。
       - name: Install dependencies with Poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
     steps:
       # リポジトリのチェックアウト
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           # 認証情報を永続化しない (セキュリティのため)
           persist-credentials: false
 
       # Python環境のセットアップ
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@v5
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
@@ -41,7 +41,9 @@ jobs:
 
       # Poetryのインストール
       - name: Install Poetry
-        run: pip install poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies
@@ -66,14 +68,14 @@ jobs:
     steps:
       # リポジトリのチェックアウト
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@v4
         with:
           # 認証情報を永続化しない (セキュリティのため)
           persist-credentials: false
 
       # Python環境のセットアップ
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@v5
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
@@ -82,7 +84,9 @@ jobs:
 
       # Poetryのインストール
       - name: Install Poetry
-        run: pip install poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,12 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
           key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
           restore-keys: |
-            ${{ runner.os }}-python-3.13-poetry- # Pythonバージョンを3.13に更新
+            ${{ runner.os }}-python-3.13-poetry-
 
-      # プロジェクトの依存関係をインストール
+      # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
       - name: Install project dependencies
         run: |
-          poetry install --no-interaction --no-ansi
+          poetry install --no-interaction --no-ansi --with dev
 
       # コードのリンティングとフォーマットチェック (Ruffを使用)
       - name: Run linters and format check
@@ -107,12 +107,12 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
           key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
           restore-keys: |
-            ${{ runner.os }}-python-3.13-poetry- # Pythonバージョンを3.13に更新
+            ${{ runner.os }}-python-3.13-poetry-
 
-      # プロジェクトの依存関係をインストール
+      # プロジェクトの依存関係をインストール (開発用依存関係もインストールするように修正)
       - name: Install project dependencies
         run: |
-          poetry install --no-interaction --no-ansi
+          poetry install --no-interaction --no-ansi --with dev
 
       # Pytestでユニットテストを実行し、カバレッジを生成
       - name: Run unit tests with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: Python CI
 
 on:
   workflow_dispatch:
-    # 他のイベントを追加する場合は、以下のように記述します。
+    # 手動でワークフローを実行するためのイベント。
+    # pushやpull_requestイベントを追加する場合は、以下のように記述します。
     # push:
     #   branches:
     #     - main
@@ -12,118 +13,72 @@ on:
 
 jobs:
   build:
-    # ビルドジョブの名前
-    name: Build
-    # ジョブの実行環境
+    name: Build and Install Dependencies
     runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定 (分)
-    timeout-minutes: 10
-    # ジョブの権限設定 (最小権限)
+    timeout-minutes: 10 # ビルドジョブのタイムアウトを10分に設定
     permissions:
-      contents: read
+      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
     steps:
-      # リポジトリのチェックアウト
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          # 認証情報を永続化しない (セキュリティのため)
-          persist-credentials: false
+          persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境のセットアップ
       - name: Set up Python
-        uses: actions/setup-python@v5
+        id: setup-python # Pythonバージョンをキャッシュキーで使用するためにIDを設定
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          # プロジェクトで指定されているPythonバージョン
-          python-version: "3.13"
-          # actions/setup-pythonのcacheオプションはpoetry自体をインストールしないため削除
+          python-version: "3.13" # pyproject.tomlのrequires-pythonに合わせて3.13を指定
 
-      # Poetryのインストール
       - name: Install Poetry
-        run: pip install poetry
-
-      # Poetryキャッシュディレクトリの設定
-      - name: Set Poetry cache directory
-        run: echo "POETRY_CACHE_DIR=$(poetry config cache-dir)" >> $GITHUB_ENV
-
-      # Poetry依存関係キャッシュの復元
-      - name: Restore Poetry dependencies cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.POETRY_CACHE_DIR }}
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-
-
-      # Poetryの依存関係をインストール
-      - name: Install Poetry dependencies
-        # Poetryの仮想環境作成を無効化し、システムPythonにインストール
         run: |
-          poetry config virtualenvs.create false
-          poetry install --no-interaction --no-ansi
+          pip install poetry==1.8.2 # Poetryをインストール（バージョン固定）
+          poetry config virtualenvs.in-project true # 仮想環境をプロジェクト内に作成するよう設定
 
-  tests:
-    # テストジョブの名前
+      - name: Cache Poetry dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .venv # プロジェクト内の仮想環境ディレクトリをキャッシュ
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに設定
+          restore-keys: |
+            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-ansi # Poetryを使って依存関係をインストール
+
+  test:
     name: Run Tests
-    # ビルドジョブが成功した後に実行
-    needs: build
-    # ジョブの実行環境
     runs-on: ubuntu-latest
-    # ジョブのタイムアウト設定 (分)
-    timeout-minutes: 10
-    # ジョブの権限設定 (最小権限)
+    timeout-minutes: 10 # テストジョブのタイムアウトを10分に設定
+    needs: build # buildジョブが成功した後に実行
     permissions:
-      contents: read
+      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
 
     steps:
-      # リポジトリのチェックアウト
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          # 認証情報を永続化しない (セキュリティのため)
-          persist-credentials: false
+          persist-credentials: false # 認証情報を永続化しない
 
-      # Python環境のセットアップ
       - name: Set up Python
-        uses: actions/setup-python@v5
+        id: setup-python # Pythonバージョンをキャッシュキーで使用するためにIDを設定
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          # プロジェクトで指定されているPythonバージョン
-          python-version: "3.13"
-          # actions/setup-pythonのcacheオプションはpoetry自体をインストールしないため削除
+          python-version: "3.13" # pyproject.tomlのrequires-pythonに合わせて3.13を指定
 
-      # Poetryのインストール
       - name: Install Poetry
-        run: pip install poetry
-
-      # Poetryキャッシュディレクトリの設定
-      - name: Set Poetry cache directory
-        run: echo "POETRY_CACHE_DIR=$(poetry config cache-dir)" >> $GITHUB_ENV
-
-      # Poetry依存関係キャッシュの復元
-      - name: Restore Poetry dependencies cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.POETRY_CACHE_DIR }}
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-
-
-      # Poetryの依存関係をインストール
-      - name: Install Poetry dependencies
-        # Poetryの仮想環境作成を無効化し、システムPythonにインストール
         run: |
-          poetry config virtualenvs.create false
-          poetry install --no-interaction --no-ansi
+          pip install poetry==1.8.2 # Poetryをインストール（バージョン固定）
+          poetry config virtualenvs.in-project true # 仮想環境をプロジェクト内に作成するよう設定
 
-      # テストの実行
-      - name: Run unit tests
-        # poetry run を使って、Poetryが管理する環境でコマンドを実行
-        run: poetry run python -m unittest discover tests
-        # 静的解析ツール (flake8, black, mypyなど) を追加する場合は、ここにステップを追加します。
-        # 例:
-        # - name: Run Flake8
-        #   run: poetry run flake8 .
-        # - name: Run Black
-        #   run: poetry run black --check .
-        # - name: Run MyPy
-        #   run: poetry run mypy .
+      - name: Restore Poetry dependencies cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .venv # プロジェクト内の仮想環境ディレクトリをキャッシュ
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # buildジョブと同じキーでキャッシュを復元
+          restore-keys: |
+            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-
+
+      - name: Run tests
+        run: poetry run python -m unittest discover tests # Poetryの仮想環境内でunittestを実行

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,12 @@ jobs:
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
-          # Poetryのキャッシュを有効化
+          # Poetryの依存関係キャッシュを有効化
           cache: "poetry"
+
+      # Poetryのインストール
+      - name: Install Poetry
+        run: pip install poetry
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies
@@ -73,8 +77,12 @@ jobs:
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
-          # Poetryのキャッシュを有効化
+          # Poetryの依存関係キャッシュを有効化
           cache: "poetry"
+
+      # Poetryのインストール
+      - name: Install Poetry
+        run: pip install poetry
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies
@@ -85,8 +93,8 @@ jobs:
 
       # テストの実行
       - name: Run unit tests
-        # unittestを使ってテストを実行
-        run: python -m unittest discover tests
+        # poetry run を使って、Poetryが管理する環境でコマンドを実行
+        run: poetry run python -m unittest discover tests
         # 静的解析ツール (flake8, black, mypyなど) を追加する場合は、ここにステップを追加します。
         # 例:
         # - name: Run Flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12' # Python 3.12を使用。プロジェクトがPython 3.13をターゲットとしている場合は、GitHub Actionsで利用可能になり次第 '3.13' に変更を検討してください。
+          python-version: '3.13' # プロジェクトの要件に合わせてPython 3.13に修正
 
       # Poetryをインストール
       - name: Install Poetry
@@ -44,9 +44,9 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-3.12-poetry-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
           restore-keys: |
-            ${{ runner.os }}-python-3.12-poetry-
+            ${{ runner.os }}-python-3.13-poetry- # Pythonバージョンを3.13に更新
 
       # プロジェクトの依存関係をインストール
       - name: Install project dependencies
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12' # Python 3.12を使用。プロジェクトがPython 3.13をターゲットとしている場合は、GitHub Actionsで利用可能になり次第 '3.13' に変更を検討してください。
+          python-version: '3.13' # プロジェクトの要件に合わせてPython 3.13に修正
 
       # Poetryをインストール
       - name: Install Poetry
@@ -105,9 +105,9 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
-          key: ${{ runner.os }}-python-3.12-poetry-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンを3.13に更新
           restore-keys: |
-            ${{ runner.os }}-python-3.12-poetry-
+            ${{ runner.os }}-python-3.13-poetry- # Pythonバージョンを3.13に更新
 
       # プロジェクトの依存関係をインストール
       - name: Install project dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,24 @@ jobs:
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
-          # Poetryの依存関係キャッシュを有効化
-          cache: "poetry"
+          # actions/setup-pythonのcacheオプションはpoetry自体をインストールしないため削除
 
       # Poetryのインストール
       - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+        run: pip install poetry
+
+      # Poetryキャッシュディレクトリの設定
+      - name: Set Poetry cache directory
+        run: echo "POETRY_CACHE_DIR=$(poetry config cache-dir)" >> $GITHUB_ENV
+
+      # Poetry依存関係キャッシュの復元
+      - name: Restore Poetry dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.POETRY_CACHE_DIR }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies
@@ -79,14 +89,24 @@ jobs:
         with:
           # プロジェクトで指定されているPythonバージョン
           python-version: "3.13"
-          # Poetryの依存関係キャッシュを有効化
-          cache: "poetry"
+          # actions/setup-pythonのcacheオプションはpoetry自体をインストールしないため削除
 
       # Poetryのインストール
       - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+        run: pip install poetry
+
+      # Poetryキャッシュディレクトリの設定
+      - name: Set Poetry cache directory
+        run: echo "POETRY_CACHE_DIR=$(poetry config cache-dir)" >> $GITHUB_ENV
+
+      # Poetry依存関係キャッシュの復元
+      - name: Restore Poetry dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.POETRY_CACHE_DIR }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
 
       # Poetryの依存関係をインストール
       - name: Install Poetry dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,84 +1,92 @@
-name: Python CI
-
+name: CI
 on:
   workflow_dispatch:
-    # 手動でワークフローを実行するためのイベント。
-    # pushやpull_requestイベントを追加する場合は、以下のように記述します。
     # push:
-    #   branches:
-    #     - main
+    #   branches: [ main ]
     # pull_request:
-    #   branches:
-    #     - main
+    #   branches: [ main ]
 
 jobs:
   build:
-    name: Build and Install Dependencies
+    name: ビルド
     runs-on: ubuntu-latest
-    timeout-minutes: 10 # ビルドジョブのタイムアウトを10分に設定
     permissions:
-      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
-
+      contents: read # リポジトリのコンテンツを読み取るための最小権限
+      actions: write # アーティファクトをアップロードするための権限
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
     steps:
-      - name: Checkout Repository
+      - name: リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない
 
-      - name: Set up Python
-        id: setup-python # Pythonバージョンをキャッシュキーで使用するためにIDを設定
+      - name: Python 3.13 をセットアップ
+        id: setup-python # 後続のステップでPythonバージョンを参照するためにIDを設定
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13" # pyproject.tomlのrequires-pythonに合わせて3.13を指定
+          python-version: "3.13" # pyproject.toml に基づくPythonバージョン
 
-      - name: Install Poetry
-        run: |
-          pip install poetry==1.8.2 # Poetryをインストール（バージョン固定）
-          poetry config virtualenvs.in-project true # 仮想環境をプロジェクト内に作成するよう設定
-
-      - name: Cache Poetry dependencies
+      - name: Poetry キャッシュを復元
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: .venv # プロジェクト内の仮想環境ディレクトリをキャッシュ
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに設定
+          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキャッシュキー
           restore-keys: |
-            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-
+            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry- # 復元キー
 
-      - name: Install dependencies
-        run: poetry install --no-interaction --no-ansi # Poetryを使って依存関係をインストール
+      - name: Poetry をインストール
+        run: |
+          pip install poetry==1.8.2 # Poetryのバージョンを固定してインストール
 
-  test:
-    name: Run Tests
+      - name: 依存関係をインストール
+        run: |
+          poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
+
+      - name: パッケージをビルド
+        run: |
+          poetry build # プロジェクトのパッケージをビルド
+
+      - name: ビルド成果物をアップロード
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist # アーティファクト名
+          path: dist/ # ビルド成果物のパス
+
+  tests:
+    name: テスト
     runs-on: ubuntu-latest
-    timeout-minutes: 10 # テストジョブのタイムアウトを10分に設定
-    needs: build # buildジョブが成功した後に実行
     permissions:
-      contents: read # リポジトリのコンテンツを読み取る権限のみを付与
-
+      contents: read # リポジトリのコンテンツを読み取るための最小権限
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    needs: build # ビルドジョブが成功した後に実行
     steps:
-      - name: Checkout Repository
+      - name: リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false # 認証情報を永続化しない
 
-      - name: Set up Python
-        id: setup-python # Pythonバージョンをキャッシュキーで使用するためにIDを設定
+      - name: Python 3.13 をセットアップ
+        id: setup-python # 後続のステップでPythonバージョンを参照するためにIDを設定
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13" # pyproject.tomlのrequires-pythonに合わせて3.13を指定
+          python-version: "3.13" # pyproject.toml に基づくPythonバージョン
 
-      - name: Install Poetry
-        run: |
-          pip install poetry==1.8.2 # Poetryをインストール（バージョン固定）
-          poetry config virtualenvs.in-project true # 仮想環境をプロジェクト内に作成するよう設定
-
-      - name: Restore Poetry dependencies cache
+      - name: Poetry キャッシュを復元
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: .venv # プロジェクト内の仮想環境ディレクトリをキャッシュ
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # buildジョブと同じキーでキャッシュを復元
+          path: ~/.cache/pypoetry/virtualenvs # Poetryの仮想環境キャッシュパス
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュに基づくキャッシュキー
           restore-keys: |
-            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-
+            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry- # 復元キー
 
-      - name: Run tests
-        run: poetry run python -m unittest discover tests # Poetryの仮想環境内でunittestを実行
+      - name: Poetry をインストール
+        run: |
+          pip install poetry==1.8.2 # Poetryのバージョンを固定してインストール
+
+      - name: 依存関係をインストール
+        run: |
+          poetry install --no-interaction --no-ansi # poetry.lockに基づいて依存関係をインストール
+
+      - name: ユニットテストを実行
+        run: |
+          python -m unittest discover tests # unittestモジュールを使用してテストを実行

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,11 @@ jobs:
           cache: "poetry" # poetryの依存関係をキャッシュします
 
       # Poetryをインストールします。
-      # pipx経由でPoetryをインストールし、PATHに追加します。
+      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
       - name: Install Poetry
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pipx
-          python -m pipx ensurepath
-          pipx install poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+        with:
+          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
 
       # poetryの依存関係をインストールします。
       # --no-interaction --no-ansi はCI環境での非対話的なインストールに適しています。
@@ -108,12 +106,11 @@ jobs:
           cache: "poetry"
 
       # Poetryをインストールします。
+      # snok/install-poetry@v1 アクションを使用して、Poetryを確実にインストールし、PATHに追加します。
       - name: Install Poetry
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pipx
-          python -m pipx ensurepath
-          pipx install poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+        with:
+          version: '1.x.x' # 使用したいPoetryのバージョンを指定 (例: '1.8.2' や 'latest')
 
       # poetryの依存関係をインストールします。
       - name: Install dependencies with Poetry
@@ -124,4 +121,4 @@ jobs:
       # pytest-covプラグインを使用してカバレッジレポートを生成します。
       - name: Run unit tests with Pytest
         run: |
-          poetry run pytest --cov=./ --cov-report=xml-
+          poetry run pytest --cov=./ --cov-report=xml


### PR DESCRIPTION
このプルリクエストでは、GitHub ActionsのCI（継続的インテグレーション）ワークフローを導入します。

## 1. ワークフロー全体の目的や概要

このワークフローは、Pythonプロジェクトの品質を自動的にチェックするためのものです。具体的には、以下の2つの主要なタスクを実行します。

1.  **Pythonパッケージのビルド**: プロジェクトのコードから配布可能なPythonパッケージを作成します。
2.  **テストの実行**: プロジェクトに含まれるユニットテストを実行し、コードが正しく動作するかを確認します。

現在はGitHubのWeb UIから手動で実行する設定になっていますが、将来的にはコードのプッシュやプルリクエスト時に自動で実行されるように拡張できます。

## 2. 各ジョブ・ステップごとの解説

### ワークフローの実行タイミング (`on`)

```yaml
on:
  workflow_dispatch:
    # 手動でワークフローを実行するためのイベント。
    #
    # 他のイベントを追加する場合は、以下のように記述します。
    # push:
    #   branches:
    #     - main
    # pull_request:
    #   branches:
    #     - main
```
*   **役割・ポイント**:
    *   このワークフローが「いつ」実行されるかを定義しています。
    *   `workflow_dispatch:` は、GitHubのWeb UI（Actionsタブ）から手動でこのワークフローを実行できるようにする設定です。
    *   コメントアウトされている `push` や `pull_request` を有効にすると、コードが特定のブランチにプッシュされたり、プルリクエストが作成されたりしたときに自動でワークフローが実行されるようになります。
*   **補足説明**:
    *   `on:` は「イベントトリガー」と呼ばれ、ワークフローの開始条件を指定します。
    *   `workflow_dispatch` は、開発者が任意のタイミングでワークフローを動かしたい場合に便利です。

### ジョブの定義 (`jobs`)

ワークフローは複数の「ジョブ」で構成されます。このワークフローには `build` と `tests` の2つのジョブがあります。

#### ジョブ: `build` (Pythonパッケージのビルド)

このジョブは、Pythonプロジェクトのパッケージを実際に作成（ビルド）する役割を担います。

```yaml
  build:
    # Pythonパッケージをビルドするジョブ
    name: Build Python Package
    runs-on: ubuntu-latest
    permissions:
      contents: write # リポジトリのチェックアウトとアーティファクトのアップロードに必要
    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
```
*   **役割・ポイント**:
    *   `name: Build Python Package`: GitHub ActionsのUI上で表示されるジョブの名前です。
    *   `runs-on: ubuntu-latest`: このジョブを実行する仮想環境を指定しています。ここでは最新版のUbuntu Linux環境を使用します。
    *   `permissions: contents: write`: このジョブがリポジトリの内容を読み書きする権限を持つことを示します。後述の「アーティファクトのアップロード」に必要です。
    *   `timeout-minutes: 10`: このジョブが最大で10分間実行されることを保証します。10分を超えると強制的に終了します。
*   **補足説明**:
    *   `runs-on` は、ジョブが実行される仮想環境（ランナー）を指定します。`ubuntu-latest` の他に `windows-latest` や `macos-latest` などもあります。
    *   `permissions` は、セキュリティのためにジョブが必要とする最小限の権限を与えるための設定です。

##### ステップ: `Checkout repository` (リポジトリのチェックアウト)

```yaml
    steps:
      - name: Checkout repository # リポジトリをチェックアウト
        uses: actions/checkout@v4
        with:
          persist-credentials: false # 認証情報を永続化しない
```
*   **役割・ポイント**:
    *   `name: Checkout repository`: ステップの名前です。
    *   `uses: actions/checkout@v4`: GitHubが提供する `checkout` アクションを使って、現在のリポジトリのコードを仮想環境にダウンロードします。
    *   `persist-credentials: false`: 認証情報を永続化しない設定です。通常は不要ですが、セキュリティ上の理由で明示的に指定されることがあります。
*   **補足説明**:
    *   `uses:` は、他の人が作成したアクション（再利用可能な処理のまとまり）を利用する際に使います。`actions/checkout@v4` は、リポジトリのコードをワークフローが実行される環境にコピーするための標準的なアクションです。

##### ステップ: `Set up Python 3.13` (Pythonのセットアップ)

```yaml
      - name: Set up Python 3.13 # Python 3.13をセットアップ
        uses: actions/setup-python@v5
        with:
          python-version: "3.13" # pyproject.tomlのrequires-pythonに合わせて3.13を指定
```
*   **役割・ポイント**:
    *   `uses: actions/setup-python@v5`: Python環境をセットアップするためのアクションです。
    *   `python-version: "3.13"`: 仮想環境にPython 3.13をインストールし、利用できるように設定します。プロジェクトの `pyproject.toml` などで指定されているPythonバージョンと合わせることが重要です。
*   **補足説明**:
    *   `actions/setup-python` は、特定のPythonバージョンを簡単に利用できるようにしてくれる便利なアクションです。

##### ステップ: `Install Poetry` (Poetryのインストール)

```yaml
      - name: Install Poetry # Poetryをインストール
        run: pip install poetry
```
*   **役割・ポイント**:
    *   `run: pip install poetry`: Pythonのパッケージ管理ツールであるPoetryをインストールします。
*   **補足説明**:
    *   `run:` は、仮想環境でシェルコマンドを実行する際に使います。ここでは `pip` コマンドを使ってPoetryをインストールしています。

##### ステップ: `Cache Poetry dependencies` (Poetryの依存関係をキャッシュ)

```yaml
      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
        uses: actions/cache@v4
        with:
          path: ~/.cache/pypoetry # Poetryのキャッシュパス
          key: python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンとpoetry.lockのハッシュをキーに設定
          restore-keys: |
            python-3.13-poetry- # キャッシュが見つからない場合に復元を試みるキー
```
*   **役割・ポイント**:
    *   `uses: actions/cache@v4`: 依存関係のインストール時間を短縮するために、以前の実行でダウンロードしたパッケージをキャッシュ（一時保存）します。
    *   `path: ~/.cache/pypoetry`: キャッシュするディレクトリを指定しています。Poetryが依存関係を保存する場所です。
    *   `key: python-3.13-poetry-${{ hashFiles('**/poetry.lock') }}`: キャッシュを識別するためのキーです。`poetry.lock` ファイルの内容が変わると、新しいキャッシュが作成されます。これにより、依存関係が変更された場合にのみ再ダウンロードが行われます。
    *   `restore-keys: | python-3.13-poetry-`: 完全一致するキーが見つからなかった場合に、部分的に一致するキーでキャッシュを復元しようとします。
*   **補足説明**:
    *   `actions/cache` は、ビルドやテストの時間を短縮するための非常に重要なアクションです。特に依存関係のインストールは時間がかかるため、キャッシュすることでCIの実行時間を大幅に削減できます。
    *   `hashFiles('**/poetry.lock')` は、指定されたファイルのハッシュ値（内容を元に生成される一意の文字列）を計算し、キャッシュキーの一部として利用します。

##### ステップ: `Install dependencies` (プロジェクトの依存関係をインストール)

```yaml
      - name: Install dependencies # プロジェクトの依存関係をインストール
        run: poetry install --no-interaction --no-ansi # Poetryを使って依存関係をインストール
```
*   **役割・ポイント**:
    *   `run: poetry install --no-interaction --no-ansi`: Poetryを使って、プロジェクトに必要なライブラリ（依存関係）をインストールします。
    *   `--no-interaction`: 対話モードを無効にします。CI環境ではユーザーの入力を待つことができないため必須です。
    *   `--no-ansi`: ANSIエスケープシーケンス（色付けなど）を無効にします。ログが見やすくなります。
*   **補足説明**:
    *   `poetry install` は、`pyproject.toml` と `poetry.lock` に基づいてプロジェクトの依存関係をインストールします。

##### ステップ: `Build package` (Pythonパッケージのビルド)

```yaml
      - name: Build package # Pythonパッケージをビルド
        run: poetry build # Poetryを使ってパッケージをビルド
```
*   **役割・ポイント**:
    *   `run: poetry build`: Poetryを使って、配布可能なPythonパッケージ（通常は `.whl` や `.tar.gz` ファイル）を作成します。これらのファイルは `dist/` ディレクトリに生成されます。
*   **補足説明**:
    *   `poetry build` は、プロジェクトをPyPIなどのパッケージリポジトリに公開するための準備を行います。

##### ステップ: `Upload artifacts` (ビルドされたパッケージをアーティファクトとしてアップロード)

```yaml
      - name: Upload artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
        uses: actions/upload-artifact@v4
        with:
          name: python-package # アーティファクトの名前
          path: dist/ # アップロードするパス
```
*   **役割・ポイント**:
    *   `uses: actions/upload-artifact@v4`: ビルドされたファイル（この場合はPythonパッケージ）を「アーティファクト」としてGitHub Actionsの実行結果に保存します。
    *   `name: python-package`: アップロードされるアーティファクトの名前です。
    *   `path: dist/`: `dist/` ディレクトリ内のすべてのファイルをアーティファクトとしてアップロードします。
*   **補足説明**:
    *   「アーティファクト」とは、ワークフローの実行中に生成されたファイル（ビルド成果物、テストレポートなど）を指します。これらをアップロードすることで、ワークフローの実行が完了した後でも、生成されたファイルをダウンロードして確認できるようになります。

#### ジョブ: `tests` (プロジェクトのテスト実行)

このジョブは、ビルドジョブが成功した後に、プロジェクトのテストを実行する役割を担います。

```yaml
  tests:
    # プロジェクトのテストを実行するジョブ
    name: Run Tests
    runs-on: ubuntu-latest
    permissions:
      contents: read # リポジトリのチェックアウトに必要
    timeout-minutes: 10 # ジョブの最大実行時間を10分に設定
    needs: build # ビルドジョブが成功した後に実行
```
*   **役割・ポイント**:
    *   `name: Run Tests`: GitHub ActionsのUI上で表示されるジョブの名前です。
    *   `runs-on: ubuntu-latest`: `build` ジョブと同様に、最新版のUbuntu Linux環境で実行します。
    *   `permissions: contents: read`: このジョブはリポジトリの内容を読み込むだけでよいため、`read` 権限のみを与えています。
    *   `timeout-minutes: 10`: このジョブも最大10分で終了します。
    *   `needs: build`: この設定が重要です。`tests` ジョブは `build` ジョブが**成功した場合にのみ**実行されます。これにより、ビルドが失敗したのにテストが実行される無駄を防ぎます。
*   **補足説明**:
    *   `needs:` は、ジョブ間の依存関係を定義します。複数のジョブを並行して実行したり、特定の順序で実行したりする際に使います。

##### ステップ: `Checkout repository` から `Install dependencies` まで

これらのステップは `build` ジョブと全く同じです。テストを実行するために、まずリポジトリのコードを仮想環境にダウンロードし、PythonとPoetryをセットアップし、依存関係をインストールする必要があります。

```yaml
    steps:
      - name: Checkout repository # リポジリをチェックアウト
        uses: actions/checkout@v4
        with:
          persist-credentials: false # 認証情報を永続化しない

      - name: Set up Python 3.13 # Python 3.13をセットアップ
        uses: actions/setup-python@v5
        with:
          python-version: "3.13" # pyproject.tomlのrequires-pythonに合わせて3.13を指定

      - name: Install Poetry # Poetryをインストール
        run: pip install poetry

      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
        uses: actions/cache@v4
        with:
          path: ~/.cache/pypoetry # Poetryのキャッシュパス
          key: python-3.13-poetry-${{ hashFiles('**/poetry.lock') }} # Pythonバージョンとpoetry.lockのハッシュをキーに設定
          restore-keys: |
            python-3.13-poetry- # キャッシュが見つからない場合に復元を試みるキー

      - name: Install dependencies # プロジェクトの依存関係をインストール
        run: poetry install --no-interaction --no-ansi # Poetryを使って依存関係をインストール
```
*   **役割・ポイント**:
    *   `build` ジョブと同様に、テスト実行に必要な環境を準備します。
    *   キャッシュも利用することで、テスト実行前の依存関係インストール時間を短縮します。

##### ステップ: `Run unit tests` (ユニットテストの実行)

```yaml
      - name: Run unit tests # ユニットテストを実行
        run: python -m unittest discover tests # unittestモジュールを使ってtestsディレクトリ内のテストを発見し実行
```
*   **役割・ポイント**:
    *   `run: python -m unittest discover tests`: Pythonの標準テストフレームワークである `unittest` を使って、`tests` ディレクトリ内にあるすべてのテストファイルを発見し、実行します。
*   **補足説明**:
    *   このコマンドが成功（終了コード0）すればテストは合格、失敗（終了コード0以外）すればテストは不合格となり、ジョブ全体も失敗と判断されます。

## 3. 注意点やよくあるミス

*   **自動実行のトリガー**: 現在は `workflow_dispatch` のみなので、手動で実行しない限りワークフローは動きません。プルリクエスト時やプッシュ時に自動で実行したい場合は、`on:` の設定に `pull_request` や `push` イベントを追加する必要があります。
*   **Pythonバージョンの整合性**: `actions/setup-python` で指定している `python-version: "3.13"` は、プロジェクトの `pyproject.toml` や `requirements.txt` などで指定されているPythonバージョンと一致させるようにしてください。異なるバージョンを指定すると、依存関係のインストールやテスト実行時に問題が発生する可能性があります。
*   **`poetry.lock` の管理**: `actions/cache` ステップでは `poetry.lock` ファイルのハッシュ値を使ってキャッシュを管理しています。`poetry.lock` はプロジェクトの依存関係を固定する重要なファイルなので、依存関係を変更した際は必ずコミットするようにしてください。このファイルが最新でないと、CI環境とローカル環境で依存関係が異なり、予期せぬエラーが発生することがあります。
*   **権限 (`permissions`)**: ジョブに必要な最小限の権限を与えるようにしましょう。`build` ジョブではアーティファクトのアップロードのために `contents: write` が必要ですが、`tests` ジョブでは読み込みだけで十分なので `contents: read` としています。過剰な権限はセキュリティリスクにつながる可能性があります。
*   **タイムアウト (`timeout-minutes`)**: ジョブが無限に実行されるのを防ぐために `timeout-minutes` を設定しています。もしジョブが頻繁にタイムアウトする場合は、処理の最適化を検討するか、タイムアウト時間を延長する必要があります。