### PR TITLE
GitHubワークフローファイルの作成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: Python CI
+
+# ワークフローがトリガーされるイベントを定義します。
+# pushイベントで、すべてのブランチに対して実行されます。
+# 他のイベント（例: pull_request, workflow_dispatch）を追加する場合は、以下のように記述します。
+# on:
+#   push:
+#   pull_request:
+#     branches: [ main ]
+#   workflow_dispatch:
+on:
+  push:
+
+# 同時実行設定。同じブランチでの重複実行を防ぎます。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ビルドジョブ
+  build:
+    name: Build and Lint
+    runs-on: ubuntu-latest
+    # ジョブのタイムアウト設定
+    timeout-minutes: 10
+    # 最小限の権限を設定
+    permissions:
+      contents: read # リポジトリのコードを読み取るため
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+    steps:
+      # リポジトリをチェックアウトします
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+
+      # 指定されたPythonバージョンをセットアップします
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Poetryをインストールします
+      - name: Install Poetry
+        run: |
+          pip install poetry
+
+      # Poetryのキャッシュを復元または保存します
+      - name: Restore Poetry cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
+
+      # 依存関係をインストールします
+      - name: Install dependencies
+        run: |
+          # CI環境で仮想環境を作成しないように設定
+          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
+
+      # コードのフォーマットチェック (Black)
+      - name: Check code format with Black
+        run: |
+          poetry run black --check .
+
+      # コードのリンティング (Ruff)
+      - name: Lint code with Ruff
+        run: |
+          poetry run ruff check .
+
+  # テストジョブ
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    # ビルドジョブが成功した場合にのみ実行
+    needs: build
+    # ジョブのタイムアウト設定
+    timeout-minutes: 15
+    # 最小限の権限を設定
+    permissions:
+      contents: read # リポジトリのコードを読み取るため
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
+    steps:
+      # リポジトリをチェックアウトします
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
+
+      # 指定されたPythonバージョンをセットアップします
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Poetryをインストールします
+      - name: Install Poetry
+        run: |
+          pip install poetry
+
+      # Poetryのキャッシュを復元または保存します
+      - name: Restore Poetry cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
+
+      # 依存関係をインストールします
+      - name: Install dependencies
+        run: |
+          # CI環境で仮想環境を作成しないように設定
+          poetry config virtualenvs.create false
+          poetry install --no-interaction --no-ansi
+
+      # Pytestを使用してテストを実行します
+      - name: Run tests with Pytest
+        run: |
+          poetry run pytest


### PR DESCRIPTION
【GitHub Actionsワークフローの解説】
このYAMLファイルは、Pythonプロジェクトの継続的インテグレーション（CI）ワークフローを定義しています。プルリクエストの説明文として、以下の内容をご活用ください。

---

### 1. ワークフロー全体の目的と概要

このプルリクエストでは、Pythonプロジェクトのコード品質を自動的にチェックし、テストを実行するためのGitHub Actionsワークフローを追加します。コードがGitHubにプッシュされるたびに自動で実行され、以下のことを確認します。

*   **複数のPythonバージョンでの動作確認**: Python 3.10, 3.11, 3.12 の各バージョンでコードが正しく動作するかを確認します。
*   **コードフォーマットのチェック**: コードが決められたスタイル（Black）に従っているかを確認します。
*   **コードの品質チェック（リンティング）**: コードに潜在的な問題やバグがないか（Ruff）を確認します。
*   **単体テストの実行**: コードが意図した通りに機能するかをテスト（Pytest）で確認します。

これにより、コードの品質を一定に保ち、バグの混入を防ぎ、開発チーム全体の生産性向上に貢献します。

---
### 2. 各ジョブ・ステップの詳細

このワークフローは、大きく分けて「ビルドとリンティング（`build`）」、「テスト実行（`tests`）」の2つのジョブで構成されています。

#### ワークフローの基本設定

##### ワークフロー名
```yaml
name: Python CI
```
*   **役割**: このワークフローの名前を「Python CI」と設定しています。GitHubのActionsタブでこの名前が表示されます。

##### 実行トリガー
```yaml
on:
  push:
```
*   **役割**: このワークフローがいつ実行されるかを定義しています。
*   **ポイント**: `push`イベント、つまりコードがリポジトリにプッシュ（コミットがGitHubにアップロード）されるたびに実行されます。
*   **補足**: コメントアウトされている部分には、プルリクエスト時や手動実行（`workflow_dispatch`）など、他のトリガーを追加する方法が示されています。

##### 同時実行制御
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
*   **役割**: 同じブランチで複数のワークフローが同時に実行されるのを防ぎ、最新の実行のみを有効にする設定です。
*   **ポイント**:
    *   `group`: 実行中のワークフローを識別するためのグループ名を設定します。ここでは「ワークフロー名-ブランチ名」という形式で、ブランチごとにユニークなグループを作っています。
    *   `cancel-in-progress: true`: 同じグループのワークフローがすでに実行中の場合、新しいワークフローが開始されると、古い実行は自動的にキャンセルされます。これにより、無駄なリソース消費を防ぎ、常に最新のコードに対する結果が得られます。

#### ジョブ1: `build` (ビルドとリンティング)

このジョブでは、コードの準備、依存関係のインストール、そしてコードのフォーマットチェックとリンティングを行います。

##### ジョブの基本設定
```yaml
jobs:
  build:
    name: Build and Lint
    runs-on: ubuntu-latest
    timeout-minutes: 10
    permissions:
      contents: read # リポジトリのコードを読み取るため
    strategy:
      matrix:
        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
```
*   **役割**: `build`ジョブの全体的な設定です。
*   **ポイント**:
    *   `name: Build and Lint`: ジョブの名前です。
    *   `runs-on: ubuntu-latest`: このジョブを実行する環境を指定しています。GitHubが提供する最新のUbuntu Linux環境で実行されます。
    *   `timeout-minutes: 10`: このジョブが10分を超えて実行された場合、自動的にキャンセルされます。無限に実行されるのを防ぐための安全策です。
    *   `permissions: contents: read`: このジョブがリポジトリのコードを読み取るための最小限の権限を与えています。セキュリティの観点から、必要な権限のみを与えるのがベストプラクティスです。
    *   `strategy: matrix`: 「マトリックス戦略」と呼ばれる機能です。`python-version`に指定された複数の値（3.10, 3.11, 3.12）それぞれに対して、このジョブ全体が独立して実行されます。これにより、異なるPythonバージョンでの互換性を一度に確認できます。

##### ステップ1: リポジトリのチェックアウト
```yaml
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）
```
*   **役割**: GitHubリポジトリから最新のコードを、実行環境（ランナー）にダウンロードします。
*   **ポイント**:
    *   `uses: actions/checkout@v4`: GitHubが公式に提供している「checkout」アクションのバージョン4を使用します。
    *   `persist-credentials: false`: セキュリティのため、リポジトリへの認証情報を永続化しない設定です。これにより、機密情報がランナー環境に残るリスクを減らします。

##### ステップ2: Pythonのセットアップ
```yaml
      - name: Set up Python ${{ matrix.python-version }}
        uses: actions/setup-python@v5
        with:
          python-version: ${{ matrix.python-version }}
```
*   **役割**: マトリックス戦略で指定されたPythonバージョンをランナー環境にセットアップします。
*   **ポイント**:
    *   `uses: actions/setup-python@v5`: GitHubが公式に提供している「setup-python」アクションのバージョン5を使用します。
    *   `python-version: ${{ matrix.python-version }}`: マトリックス戦略で現在処理中のPythonバージョン（例: 3.10, 3.11, 3.12）を動的に指定します。

##### ステップ3: Poetryのインストール
```yaml
      - name: Install Poetry
        run: |
          pip install poetry
```
*   **役割**: Pythonの依存関係管理ツールであるPoetryをインストールします。
*   **ポイント**: `pip install poetry`コマンドを使って、Poetryをシステムにインストールします。

##### ステップ4: Poetryキャッシュの復元/保存
```yaml
      - name: Restore Poetry cache
        uses: actions/cache@v4
        with:
          path: ~/.cache/pypoetry/virtualenvs
          key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
          restore-keys: |
            ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-
```
*   **役割**: 以前のワークフロー実行でインストールされたPoetryの仮想環境や依存関係をキャッシュし、次回の実行時に再利用することで、依存関係のインストール時間を短縮します。
*   **ポイント**:
    *   `uses: actions/cache@v4`: GitHubが公式に提供している「cache」アクションのバージョン4を使用します。
    *   `path`: キャッシュするディレクトリのパスを指定します。ここではPoetryが仮想環境を作成する場所を指定しています。
    *   `key`: キャッシュを一意に識別するためのキーです。OS、Pythonバージョン、Poetry、そして`poetry.lock`ファイルの内容（ハッシュ値）に基づいてキーが生成されます。`poetry.lock`ファイルが変更された場合、新しいキャッシュが作成されます。
    *   `restore-keys`: `key`に完全に一致するキャッシュが見つからなかった場合に、部分的に一致するキャッシュを探して復元するためのキーです。これにより、`poetry.lock`が少しだけ変更された場合でも、ある程度のキャッシュを再利用できる可能性があります。

##### ステップ5: 依存関係のインストール
```yaml
      - name: Install dependencies
        run: |
          # CI環境で仮想環境を作成しないように設定
          poetry config virtualenvs.create false
          poetry install --no-interaction --no-ansi
```
*   **役割**: `poetry.lock`ファイルに基づいて、プロジェクトに必要なPythonの依存関係をインストールします。
*   **ポイント**:
    *   `poetry config virtualenvs.create false`: CI環境では、Poetryが自動的に仮想環境を作成するのを無効にしています。これは、`actions/setup-python`がすでに適切なPython環境をセットアップしているため、Poetryがさらに仮想環境を作成すると二重になり、パスの問題などを引き起こす可能性があるためです。
    *   `poetry install --no-interaction --no-ansi`:
        *   `poetry install`: `poetry.lock`ファイルに記載されている依存関係をインストールします。
        *   `--no-interaction`: インストール中にユーザーからの入力を求めないようにします（CI環境では対話操作ができないため必須）。
        *   `--no-ansi`: ANSIエスケープシーケンス（色付けなど）を出力しないようにします。ログが見やすくなります。

##### ステップ6: コードフォーマットのチェック (Black)
```yaml
      - name: Check code format with Black
        run: |
          poetry run black --check .
```
*   **役割**: PythonのコードフォーマッターであるBlackを使って、コードが決められたスタイルガイドに従っているかを確認します。
*   **ポイント**:
    *   `poetry run black --check .`: プロジェクトルート（`.`）以下のすべてのPythonファイルに対してBlackを実行します。
    *   `--check`: コードを実際にフォーマットするのではなく、フォーマットが必要な箇所があるかどうかをチェックするだけです。もしフォーマットが必要なファイルがあれば、このステップは失敗します。

##### ステップ7: コードのリンティング (Ruff)
```yaml
      - name: Lint code with Ruff
        run: |
          poetry run ruff check .
```
*   **役割**: PythonのリンターであるRuffを使って、コードに潜在的な問題（バグ、非効率なコード、スタイル違反など）がないかを確認します。
*   **ポイント**:
    *   `poetry run ruff check .`: プロジェクトルート（`.`）以下のすべてのPythonファイルに対してRuffを実行します。
    *   `check`: コードを修正するのではなく、問題点を報告するだけです。問題が見つかれば、このステップは失敗します。

#### ジョブ2: `tests` (テスト実行)

このジョブでは、`build`ジョブが成功した後に、実際にコードのテストを実行します。

##### ジョブの基本設定
```yaml
  tests:
    name: Run Tests
    runs-on: ubuntu-latest
    needs: build
    timeout-minutes: 15
    permissions:
      contents: read # リポジトリのコードを読み取るため
    strategy:
      matrix:
        python-version: ["3.10", "3.11", "3.12"] # 複数のPythonバージョンでテスト
```
*   **役割**: `tests`ジョブの全体的な設定です。
*   **ポイント**:
    *   `name: Run Tests`: ジョブの名前です。
    *   `needs: build`: この設定が重要です。`tests`ジョブは、`build`ジョブが**すべて成功した場合にのみ**実行されます。これにより、フォーマットやリンティングに問題があるコードに対して無駄にテストを実行するのを防ぎます。
    *   `timeout-minutes: 15`: このジョブが15分を超えて実行された場合、自動的にキャンセルされます。
    *   `permissions: contents: read`: `build`ジョブと同様に、リポジトリのコードを読み取るための最小限の権限を与えています。
    *   `strategy: matrix`: `build`ジョブと同様に、複数のPythonバージョンでテストを実行します。

##### ステップ1〜5: リポジトリのチェックアウト、Pythonセットアップ、Poetryインストール、キャッシュ、依存関係インストール
```yaml
    steps:
      # リポジトリをチェックアウトします
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          persist-credentials: false # 認証情報を永続化しない（セキュリティのため）

      # 指定されたPythonバージョンをセットアップします
      - name: Set up Python ${{ matrix.python-version }}
        uses: actions/setup-python@v5
        with:
          python-version: ${{ matrix.python-version }}

      # Poetryをインストールします
      - name: Install Poetry
        run: |
          pip install poetry

      # Poetryのキャッシュを復元または保存します
          # path: ~/.cache/pypoetry/virtualenvs
          # key: ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
          # restore-keys: |
          #   ${{ runner.os }}-python-${{ matrix.python-version }}-poetry-

      # 依存関係をインストールします
      - name: Install dependencies
        run: |
          # CI環境で仮想環境を作成しないように設定
          poetry config virtualenvs.create false
          poetry install --no-interaction --no-ansi
```
*   **役割**: `build`ジョブと全く同じ内容です。テストを実行するために、再度コードのダウンロード、Python環境のセットアップ、Poetryのインストール、キャッシュの利用、依存関係のインストールを行います。
*   **ポイント**: `needs: build`で依存関係があるため、`build`ジョブでこれらの準備が完了しているように見えますが、GitHub Actionsのジョブはそれぞれ独立した環境で実行されます。そのため、`tests`ジョブでも改めてこれらの準備が必要です。

##### ステップ6: Pytestを使用してテストを実行
```yaml
      - name: Run tests with Pytest
        run: |
          poetry run pytest
```
*   **役割**: PythonのテストフレームワークであるPytestを使って、プロジェクトのテストコードを実行します。
*   **ポイント**:
    *   `poetry run pytest`: Poetryの仮想環境内で`pytest`コマンドを実行します。これにより、プロジェクトのテストが実行され、コードが期待通りに動作するかを確認します。テストが一つでも失敗した場合、このステップは失敗し、ワークフロー全体も失敗とみなされます。

---
### 3. 注意点やよくあるミス

*   **`poetry.lock`ファイルの管理**: `poetry.lock`ファイルは、プロジェクトの依存関係とそのバージョンを厳密に固定する重要なファイルです。このファイルはGitで管理し、変更があった場合は必ずコミットするようにしてください。`poetry.lock`が更新されていないと、CIとローカル環境で依存関係が異なり、問題が発生する可能性があります。
*   **キャッシュの有効活用**: `actions/cache`はCIの実行時間を大幅に短縮できる強力な機能です。しかし、キャッシュキーの設計を誤ると、古いキャッシュが使われたり、キャッシュが全く効かなかったりすることがあります。`poetry.lock`のハッシュ値を含めることで、依存関係が変更された場合に適切にキャッシュが更新されるようにしています。
*   **`poetry config virtualenvs.create false`**: CI環境では、`actions/setup-python`がPython環境をセットアップするため、Poetryに仮想環境を別途作成させないようにこの設定を入れています。もしこの設定がないと、Poetryが独自の仮想環境を作成しようとして、パスの問題や予期せぬエラーが発生する可能性があります。
*   **権限設定 (`permissions`)**: `contents: read`はリポジトリのコードを読み取るための最小限の権限です。もしワークフロー内でGitHub Packagesへの公開やIssueの作成など、より多くの操作が必要な場合は、適切な権限を追加する必要があります。セキュリティのため、必要最小限の権限を与えるように心がけましょう。
*   **タイムアウト設定 (`timeout-minutes`)**: 長時間実行される可能性のあるジョブには、タイムアウトを設定することが重要です。これにより、無限ループや予期せぬフリーズによってランナーリソースが無駄に消費されるのを防ぎます。

---

---

【GitHub Dependabot security updatesの設定方法と意義】
GitHubのDependabot security updatesは、あなたのプロジェクトのセキュリティを自動で守るための強力な機能です。初心者の方にも分かりやすく、その意義と設定方法を解説します。

---

### Dependabot security updatesとは？（その意義）

あなたのGitHubリポジトリが使っているライブラリやツール（「依存関係」と呼びます）に、セキュリティ上の弱点（「脆弱性」）が見つかった時、それを自動で修正してくれる便利な機能です。

**なぜ重要なのか？**

*   **セキュリティリスクの低減:** 脆弱性のある依存関係を放置すると、サイバー攻撃の標的になる可能性があります。Dependabot security updatesは、これらのリスクを自動で検知し、修正を提案することで、プロジェクトのセキュリティを常に最新の状態に保ちます。
*   **開発者の負担軽減:** 開発者が手動で脆弱性を探し、修正する手間を省きます。これにより、開発者は本来の機能開発に集中できます。
*   **GitHub Actionsの保護:** プロジェクトの自動化に使われるGitHub Actionsのワークフロー内で脆弱なアクションが使われている場合も、Dependabotが自動で修正を提案してくれます。

### Dependabot security updatesの設定方法

基本的な設定は非常に簡単です。

1.  **リポジトリのメインページに移動:** GitHubで、設定したいリポジトリを開きます。
2.  **「Settings」タブへ:** リポジトリの上部にある「Settings」（設定）タブをクリックします。
3.  **「Code security and analysis」へ:** 左側のメニューから「Code security and analysis」を選択します。
4.  **「Dependabot security updates」を有効化:** 「Dependabot security updates」の項目を見つけ、「Enable」（有効にする）ボタンをクリックします。

**これで完了です！**

有効にすると、Dependabotは脆弱性が見つかるたびに、その修正に必要な変更をまとめた「プルリクエスト（PR）」を自動で作成してくれます。あなたはそれをレビューしてマージするだけで、セキュリティ対策が完了します。

### Dependabot version updatesとの違い

Dependabotには、似た名前の機能がもう一つあります。

*   **Dependabot security updates:** **脆弱性が見つかった**依存関係を修正するためのPRを自動作成します。
*   **Dependabot version updates:** **脆弱性がなくても**、依存関係を常に最新バージョンに保つためのPRを自動作成します。こちらは通常、リポジトリの`.github/dependabot.yml`ファイルを使って設定します。

**ポイント:**

*   `dependabot.yml`ファイルは主にVersion updatesの挙動を定義しますが、一部の設定はSecurity updatesにも影響を与えることがあります。
*   例えば、「セキュリティアップデートは欲しいけど、バージョンアップデートは不要」という場合は、`dependabot.yml`ファイルで`open-pull-requests-limit: 0`を設定することで、バージョンアップデートのPR作成を停止しつつ、セキュリティアップデートは受け取ることができます。

### さらに高度な設定（オプション）

特定の依存関係だけを無視したり、複数のセキュリティアップデートを一つのPRにまとめたり（グループ化）、PRの作成頻度を調整したりするなど、`dependabot.yml`ファイルを使ってより詳細なカスタマイズも可能です。しかし、まずは上記の方法で「Dependabot security updates」を有効にすることから始めるのがおすすめです。