### PR TITLE
GitHubワークフローファイルの作成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: Python CI
 on:
   push:
     branches:
-      - work_1005_1045
-  # 他のイベントを追加する場合は、以下を参考にしてください。
+      - work_1005_1050
+  # 他のイベントを追加する場合は、以下のコメントアウトを解除し、必要に応じて設定してください。
   # pull_request:
   #   branches:
   #     - main
@@ -19,54 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
     permissions:
-      contents: write # アーティファクトをアップロードするために必要
-    steps:
-      - name: Checkout repository # リポジリをチェックアウト
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false # 認証情報を永続化しない
+      contents: read # lintエラー修正: ジョブレベルの最小権限を設定
 
-      - name: Set up Python # Python環境をセットアップ
-        id: setup-python # このステップにIDを設定
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.13" # Python 3.13を使用
-
-      - name: Install Poetry # Poetryをインストール
-        run: pip install poetry
-
-      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/pypoetry # Poetryのキャッシュパス
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに
-          restore-keys: |
-            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry- # キャッシュが見つからない場合の復元キー
-
-      - name: Install project dependencies # プロジェクトの依存関係をインストール
-        run: poetry install --no-interaction --no-ansi # 仮想環境を作成せず、依存関係をインストール
-
-      # Run Linter (Ruff) ステップは、ruffコマンドが見つからないため削除されました。
-      # - name: Run Linter (Ruff)
-      #   run: poetry run ruff check .
-      #   continue-on-error: true
-
-      - name: Build package # プロジェクトをビルド
-        run: poetry build # Poetryを使ってパッケージをビルド
-
-      - name: Upload build artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dist # アーティファクト名
-          path: dist/ # ビルド成果物のパス
-
-  test:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
-    needs: build # buildジョブが成功した後に実行
-    permissions:
-      contents: read # リポジトリのコンテンツを読み取るための最小権限
     steps:
       - name: Checkout repository # リポジトリをチェックアウト
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -74,25 +28,78 @@ jobs:
           persist-credentials: false # 認証情報を永続化しない
 
       - name: Set up Python # Python環境をセットアップ
-        id: setup-python # このステップにIDを設定
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        id: setup-python # lintエラー修正: ステップIDを追加
         with:
-          python-version: "3.13" # Python 3.13を使用
+          python-version: "3.13" # pyproject.tomlで指定されているPythonバージョン
 
       - name: Install Poetry # Poetryをインストール
-        run: pip install poetry
+        run: |
+          pip install poetry
+
+      - name: Configure Poetry virtualenvs # Poetryが仮想環境を作成しないように設定 (CI環境向け)
+        run: poetry config virtualenvs.create false
 
       - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        id: cache-poetry
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: ~/.cache/pypoetry # Poetryのキャッシュパス
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに
+          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry- # キャッシュが見つからない場合の復元キー
+            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-
 
-      - name: Install project dependencies # プロジェクトの依存関係をインストール
-        run: poetry install --no-interaction --no-ansi # 仮想環境を作成せず、依存関係をインストール
+      - name: Install dependencies # 依存関係をインストール
+        run: poetry install --no-interaction --no-ansi
 
-      # Run Pytest ステップは、pytestコマンドが見つからないため削除されました。
-      # - name: Run Pytest
-      #   run: poetry run pytest tests/
+      - name: Install linters # リンターをインストール
+        run: poetry add flake8 --group dev --no-update
+
+      - name: Run Lint # Lintを実行 (エラーが発生しても続行)
+        run: poetry run flake8 .
+        continue-on-error: true # Lintのエラーが発生してもジョブを続行
+
+      - name: Build package # パッケージをビルド
+        run: poetry build
+
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    needs: build # ビルドジョブが成功した後に実行
+    permissions:
+      contents: read # lintエラー修正: ジョブレベルの最小権限を設定
+
+    steps:
+      - name: Checkout repository # リポジトリをチェックアウト
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない
+
+      - name: Set up Python # Python環境をセットアップ
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        id: setup-python # lintエラー修正: ステップIDを追加
+        with:
+          python-version: "3.13" # pyproject.tomlで指定されているPythonバージョン
+
+      - name: Install Poetry # Poetryをインストール
+        run: |
+          pip install poetry
+
+      - name: Configure Poetry virtualenvs # Poetryが仮想環境を作成しないように設定 (CI環境向け)
+        run: poetry config virtualenvs.create false
+
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        id: cache-poetry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-
+
+      - name: Install dependencies # 依存関係をインストール
+        run: poetry install --no-interaction --no-ansi
+
+      - name: Run tests # テストを実行
+        run: poetry run python -m unittest discover tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,10 @@ jobs:
       - name: Install project dependencies # プロジェクトの依存関係をインストール
         run: poetry install --no-interaction --no-ansi # 仮想環境を作成せず、依存関係をインストール
 
-      - name: Run Linter (Ruff) # Ruffでコードの静的解析を実行
-        run: poetry run ruff check . # Poetry経由でRuffを実行
-        continue-on-error: true # エラーが発生してもジョブを続行
+      # Run Linter (Ruff) ステップは、ruffコマンドが見つからないため削除されました。
+      # - name: Run Linter (Ruff)
+      #   run: poetry run ruff check .
+      #   continue-on-error: true
 
       - name: Build package # プロジェクトをビルド
         run: poetry build # Poetryを使ってパッケージをビルド
@@ -92,5 +93,6 @@ jobs:
       - name: Install project dependencies # プロジェクトの依存関係をインストール
         run: poetry install --no-interaction --no-ansi # 仮想環境を作成せず、依存関係をインストール
 
-      - name: Run Pytest # Pytestで単体テストを実行
-        run: poetry run pytest tests/ # Poetry経由でPytestを実行し、testsディレクトリのテストを実行
+      # Run Pytest ステップは、pytestコマンドが見つからないため削除されました。
+      # - name: Run Pytest
+      #   run: poetry run pytest tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: poetry install --no-interaction --no-ansi
 
       - name: Install linters # リンターをインストール
-        run: poetry add flake8 --group dev --no-update
+        run: poetry add flake8 --group dev # 実行エラー修正: --no-updateオプションを削除
 
       - name: Run Lint # Lintを実行 (エラーが発生しても続行)
         run: poetry run flake8 .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: Python CI
+
+on:
+  push:
+    branches:
+      - work_1005_1045
+  # 他のイベントを追加する場合は、以下を参考にしてください。
+  # pull_request:
+  #   branches:
+  #     - main
+  # workflow_dispatch: # 手動実行を許可する場合
+
+permissions:
+  contents: read # リポジトリのコンテンツを読み取るための最小権限
+
+jobs:
+  build:
+    name: Build and Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    permissions:
+      contents: write # アーティファクトをアップロードするために必要
+    steps:
+      - name: Checkout repository # リポジリをチェックアウト
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない
+
+      - name: Set up Python # Python環境をセットアップ
+        id: setup-python # このステップにIDを設定
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13" # Python 3.13を使用
+
+      - name: Install Poetry # Poetryをインストール
+        run: pip install poetry
+
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに
+          restore-keys: |
+            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry- # キャッシュが見つからない場合の復元キー
+
+      - name: Install project dependencies # プロジェクトの依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # 仮想環境を作成せず、依存関係をインストール
+
+      - name: Run Linter (Ruff) # Ruffでコードの静的解析を実行
+        run: poetry run ruff check . # Poetry経由でRuffを実行
+        continue-on-error: true # エラーが発生してもジョブを続行
+
+      - name: Build package # プロジェクトをビルド
+        run: poetry build # Poetryを使ってパッケージをビルド
+
+      - name: Upload build artifacts # ビルドされたパッケージをアーティファクトとしてアップロード
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist # アーティファクト名
+          path: dist/ # ビルド成果物のパス
+
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
+    needs: build # buildジョブが成功した後に実行
+    permissions:
+      contents: read # リポジトリのコンテンツを読み取るための最小権限
+    steps:
+      - name: Checkout repository # リポジトリをチェックアウト
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false # 認証情報を永続化しない
+
+      - name: Set up Python # Python環境をセットアップ
+        id: setup-python # このステップにIDを設定
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13" # Python 3.13を使用
+
+      - name: Install Poetry # Poetryをインストール
+        run: pip install poetry
+
+      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pypoetry # Poetryのキャッシュパス
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }} # OS, Pythonバージョン, poetry.lockのハッシュをキーに
+          restore-keys: |
+            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry- # キャッシュが見つからない場合の復元キー
+
+      - name: Install project dependencies # プロジェクトの依存関係をインストール
+        run: poetry install --no-interaction --no-ansi # 仮想環境を作成せず、依存関係をインストール
+
+      - name: Run Pytest # Pytestで単体テストを実行
+        run: poetry run pytest tests/ # Poetry経由でPytestを実行し、testsディレクトリのテストを実行


### PR DESCRIPTION
【GitHub Actionsワークフローの解説】
このプルリクエストでは、Pythonプロジェクトの品質を自動的にチェックするためのGitHub Actionsワークフローを追加します。これにより、コードの整形チェック（Lint）と単体テストが自動的に実行され、コードの品質維持とバグの早期発見に役立ちます。

---

### 1. ワークフロー全体の目的と概要

このYAMLファイルは、Pythonプロジェクトの継続的インテグレーション（CI）ワークフローを定義しています。
簡単に言うと、**コードがリポジトリにプッシュされたときに、自動的にコードのチェック（Lint）とテストを実行し、問題がないかを確認する仕組み**です。

*   **目的**:
    *   コードの品質を一定に保つ（Lintによるコードスタイルの統一）。
    *   バグを早期に発見する（テストによる機能検証）。
    *   開発者が手動でこれらのチェックを行う手間を省き、開発効率を向上させる。
*   **実行タイミング**:
    *   `work_1005_1050` ブランチにコードがプッシュ（変更がアップロード）されたときに自動的に実行されます。
*   **構成**:
    *   `build` ジョブ: コードの準備、Lint（コード整形チェック）、パッケージのビルドを行います。
    *   `test` ジョブ: `build` ジョブが成功した後に、単体テストを実行します。

---

### 2. 各ジョブ・ステップの詳細解説

#### ワークフロー全体の設定

```yaml
name: Python CI

on:
  push:
    branches:
      - work_1005_1050
  # 他のイベントを追加する場合は、以下のコメントアウトを解除し、必要に応じて設定してください。
  # pull_request:
  #   branches:
  #     - main
  # workflow_dispatch: # 手動実行を許可する場合

permissions:
  contents: read # リポジトリのコンテンツを読み取るための最小権限
```

*   **対象コード**: 上記のYAMLコード全体
*   **役割・ポイント**:
    *   `name: Python CI`: このワークフローの名前です。GitHub Actionsの画面で表示されます。
    *   `on:`: ワークフローがいつ実行されるかを定義します。
        *   `push`: コードがリポジトリにプッシュされたときに実行されます。
        *   `branches: - work_1005_1050`: `work_1005_1050` という名前のブランチにプッシュされた場合のみ実行されます。
        *   コメントアウトされている部分は、他の実行トリガー（例: プルリクエスト時、手動実行）を追加したい場合に利用できます。
    *   `permissions: contents: read`: このワークフローがリポジトリのコンテンツ（コードなど）を読み取るための権限を設定しています。セキュリティの観点から、必要最小限の権限を与えるのがベストプラクティスです。ここでは「読み取り」のみを許可しています。
*   **補足説明**:
    *   **GitHub Actions**: GitHub上でコードのビルド、テスト、デプロイなどのタスクを自動化できるサービスです。
    *   **CI (継続的インテグレーション)**: 開発者がコードを頻繁に統合（マージ）し、自動的にビルドやテストを行うことで、問題の早期発見と解決を目指す開発手法です。

---

#### ジョブ: `build` (ビルドとLintチェック)

このジョブでは、Python環境のセットアップ、必要なライブラリのインストール、コードの整形チェック（Lint）、そしてパッケージのビルドを行います。

```yaml
jobs:
  build:
    name: Build and Lint
    runs-on: ubuntu-latest
    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
    permissions:
      contents: read # lintエラー修正: ジョブレベルの最小権限を設定
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `build`: ジョブの名前です。
    *   `name: Build and Lint`: GitHub Actionsの画面で表示される、このジョブの分かりやすい名前です。
    *   `runs-on: ubuntu-latest`: このジョブを実行する環境を指定します。ここでは、最新版のUbuntu Linux上で実行されます。
    *   `timeout-minutes: 10`: このジョブが10分を超えても完了しない場合、強制的に終了させます。無限に実行され続けるのを防ぐための設定です。
    *   `permissions: contents: read`: このジョブ内でリポジトリのコンテンツを読み取るための権限を設定しています。ワークフロー全体の設定と同様に、最小限の権限を与えています。

##### ステップ: `Checkout repository` (リポジトリのチェックアウト)

```yaml
    steps:
      - name: Checkout repository # リポジトリをチェックアウト
        uses: actions/checkout@v4
        with:
          persist-credentials: false # 認証情報を永続化しない
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Checkout repository`: このステップの名前です。
    *   `uses: actions/checkout@v4`: GitHubが提供する`checkout`アクションを使います。これは、リポジトリのコードをワークフローが実行される仮想環境にダウンロード（チェックアウト）するために必要です。
    *   `with: persist-credentials: false`: 認証情報を永続化しない設定です。セキュリティ上の理由から、通常は`false`に設定します。
*   **補足説明**:
    *   **アクション (Action)**: GitHub Actionsの基本的な構成要素で、特定のタスクを実行する再利用可能なコードの塊です。`actions/checkout@v4`は、リポジトリのコードを仮想環境にコピーする役割を持つアクションのバージョン4を指します。

##### ステップ: `Set up Python` (Python環境のセットアップ)

```yaml
      - name: Set up Python # Python環境をセットアップ
        uses: actions/setup-python@v5
        id: setup-python # lintエラー修正: ステップIDを追加
        with:
          python-version: "3.13" # pyproject.tomlで指定されているPythonバージョン
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Set up Python`: このステップの名前です。
    *   `uses: actions/setup-python@v5`: Python環境をセットアップするためのGitHubアクションを使います。
    *   `id: setup-python`: このステップに`setup-python`というIDを割り当てています。これにより、後続のステップでこのステップの出力（例: Pythonのバージョン）を参照できるようになります。
    *   `with: python-version: "3.13"`: インストールするPythonのバージョンを`3.13`に指定しています。プロジェクトの`pyproject.toml`ファイルで指定されているバージョンと合わせるのが一般的です。
*   **補足説明**:
    *   **`pyproject.toml`**: Pythonプロジェクトの設定ファイルで、依存関係やビルド設定などが記述されます。

##### ステップ: `Install Poetry` (Poetryのインストール)

```yaml
      - name: Install Poetry # Poetryをインストール
        run: |
          pip install poetry
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Install Poetry`: このステップの名前です。
    *   `run: pip install poetry`: `pip`コマンドを使って、Pythonのパッケージ管理ツールである`Poetry`をインストールします。
*   **補足説明**:
    *   **Poetry**: Pythonの依存関係管理とパッケージングを簡単に行うためのツールです。`pip`よりも高機能で、仮想環境の管理なども行えます。

##### ステップ: `Configure Poetry virtualenvs` (Poetry仮想環境の設定)

```yaml
      - name: Configure Poetry virtualenvs # Poetryが仮想環境を作成しないように設定 (CI環境向け)
        run: poetry config virtualenvs.create false
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Configure Poetry virtualenvs`: このステップの名前です。
    *   `run: poetry config virtualenvs.create false`: Poetryが自動的に仮想環境を作成しないように設定します。GitHub ActionsのようなCI環境では、通常、`setup-python`アクションが提供するPython環境を直接利用するため、Poetryが独自の仮想環境を作成する必要はありません。これにより、余計な処理を省き、実行時間を短縮できます。
*   **補足説明**:
    *   **仮想環境 (Virtual Environment)**: プロジェクトごとに独立したPython環境を作成する仕組みです。これにより、異なるプロジェクト間でライブラリのバージョンが衝突するのを防ぎます。

##### ステップ: `Cache Poetry dependencies` (Poetry依存関係のキャッシュ)

```yaml
      - name: Cache Poetry dependencies # Poetryの依存関係をキャッシュ
        id: cache-poetry
        uses: actions/cache@v4
        with:
          path: ~/.cache/pypoetry/virtualenvs # Poetryのキャッシュパス
          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
          restore-keys: |
            ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-poetry-
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Cache Poetry dependencies`: このステップの名前です。
    *   `id: cache-poetry`: このステップに`cache-poetry`というIDを割り当てています。
    *   `uses: actions/cache@v4`: ファイルやディレクトリをキャッシュするためのGitHubアクションを使います。
    *   `with:`: キャッシュの設定です。
        *   `path: ~/.cache/pypoetry/virtualenvs`: キャッシュするディレクトリのパスを指定します。Poetryが依存関係を保存する場所です。
        *   `key: ...`: キャッシュを識別するためのキーです。
            *   `runner.os`: ワークフローが実行されているOS（例: `ubuntu-latest`）。
            *   `steps.setup-python.outputs.python-version`: `Set up Python`ステップで設定したPythonのバージョン。
            *   `hashFiles('**/poetry.lock')`: プロジェクトの`poetry.lock`ファイルの内容から生成されるハッシュ値。このファイルはプロジェクトの依存関係のバージョンを固定するものです。`poetry.lock`が変更された場合（つまり依存関係が変わった場合）、新しいキャッシュが作成されます。
        *   `restore-keys: ...`: キャッシュが見つからなかった場合に、部分的に一致するキーで古いキャッシュを探して復元しようとします。
*   **補足説明**:
    *   **キャッシュ (Cache)**: 以前の実行でダウンロードしたファイルなどを保存しておき、次回の実行時に再利用することで、ワークフローの実行時間を短縮する仕組みです。特に依存関係のインストールは時間がかかるため、キャッシュは非常に有効です。

##### ステップ: `Install dependencies` (依存関係のインストール)

```yaml
      - name: Install dependencies # 依存関係をインストール
        run: poetry install --no-interaction --no-ansi
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Install dependencies`: このステップの名前です。
    *   `run: poetry install --no-interaction --no-ansi`: `Poetry`を使って、プロジェクトに必要なライブラリ（依存関係）をインストールします。
        *   `--no-interaction`: インストール中にユーザーの入力を求めないようにします。CI環境では必須です。
        *   `--no-ansi`: ANSIエスケープシーケンス（色付けなど）を出力しないようにします。CIのログを見やすくするために使われます。

##### ステップ: `Install linters` (リンターのインストール)

```yaml
      - name: Install linters # リンターをインストール
        run: poetry add flake8 --group dev # 実行エラー修正: --no-updateオプションを削除
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Install linters`: このステップの名前です。
    *   `run: poetry add flake8 --group dev`: コードの整形チェックツールである`flake8`をインストールします。
        *   `poetry add flake8`: `flake8`をプロジェクトの依存関係に追加します。
        *   `--group dev`: `flake8`を開発時のみ必要な依存関係として追加します。これにより、本番環境で不要なライブラリがインストールされるのを防ぎます。
*   **補足説明**:
    *   **リンター (Linter)**: コードのスタイルや潜在的なエラーを自動的にチェックしてくれるツールです。`flake8`はPythonで広く使われているリンターの一つです。

##### ステップ: `Run Lint` (Lintの実行)

```yaml
      - name: Run Lint # Lintを実行 (エラーが発生しても続行)
        run: poetry run flake8 .
        continue-on-error: true # Lintのエラーが発生してもジョブを続行
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Run Lint`: このステップの名前です。
    *   `run: poetry run flake8 .`: `flake8`を実行して、現在のディレクトリ（`.`）以下のPythonコードをチェックします。`poetry run`を使うことで、Poetryが管理する環境で`flake8`を実行できます。
    *   `continue-on-error: true`: **重要**。`flake8`がエラー（コードスタイル違反など）を検出しても、このジョブは失敗せずに次のステップに進みます。これにより、Lintエラーがビルドを完全に停止させることなく、警告として扱われます。
*   **補足説明**:
    *   Lintエラーは、コードの実行には影響しないが、可読性や保守性に影響する問題（例: インデントのずれ、未使用の変数）を指摘することが多いです。そのため、すぐにビルドを失敗させるのではなく、警告として扱い、後で修正する運用が一般的です。

##### ステップ: `Build package` (パッケージのビルド)

```yaml
      - name: Build package # パッケージをビルド
        run: poetry build
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Build package`: このステップの名前です。
    *   `run: poetry build`: `Poetry`を使って、Pythonパッケージをビルドします。これにより、配布可能な形式（例: `.whl`ファイルや`.tar.gz`ファイル）が作成されます。

---

#### ジョブ: `test` (テストの実行)

このジョブでは、`build`ジョブが成功した後に、単体テストを実行します。

```yaml
  test:
    name: Run Tests
    runs-on: ubuntu-latest
    timeout-minutes: 10 # ジョブのタイムアウトを10分に設定
    needs: build # ビルドジョブが成功した後に実行
    permissions:
      contents: read # lintエラー修正: ジョブレベルの最小権限を設定
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `test`: ジョブの名前です。
    *   `name: Run Tests`: GitHub Actionsの画面で表示される、このジョブの分かりやすい名前です。
    *   `runs-on: ubuntu-latest`: `build`ジョブと同様に、最新版のUbuntu Linux上で実行されます。
    *   `timeout-minutes: 10`: このジョブが10分を超えても完了しない場合、強制的に終了させます。
    *   `needs: build`: **重要**。このジョブは`build`ジョブが成功した場合にのみ実行されます。これにより、コードのビルドやLintチェックが完了してからテストが実行されることが保証されます。
    *   `permissions: contents: read`: このジョブ内でリポジトリのコンテンツを読み取るための権限を設定しています。

##### ステップ群 (リポジトリチェックアウトから依存関係インストールまで)

`test`ジョブの以下のステップは、`build`ジョブと全く同じ内容です。
*   `Checkout repository`
*   `Set up Python`
*   `Install Poetry`
*   `Configure Poetry virtualenvs`
*   `Cache Poetry dependencies`
*   `Install dependencies`

これらのステップは、テストを実行するために必要な環境（コード、Python、Poetry、依存関係）を再度セットアップするために必要です。`needs: build`で`build`ジョブの後に実行されるとはいえ、GitHub Actionsのジョブはそれぞれ独立した仮想環境で実行されるため、各ジョブで必要なセットアップを繰り返す必要があります。

##### ステップ: `Run tests` (テストの実行)

```yaml
      - name: Run tests # テストを実行
        run: poetry run python -m unittest discover tests
```

*   **対象コード**: 上記のYAMLコード
*   **役割・ポイント**:
    *   `name: Run tests`: このステップの名前です。
    *   `run: poetry run python -m unittest discover tests`: `unittest`モジュールを使って、`tests`ディレクトリ内のテストコードを実行します。
        *   `poetry run`: Poetryが管理する環境でコマンドを実行します。
        *   `python -m unittest discover tests`: Pythonの標準テストフレームワークである`unittest`を使って、`tests`ディレクトリ内のテストファイルを自動的に見つけて実行します。
*   **補足説明**:
    *   **単体テスト (Unit Test)**: プログラムの個々の小さな部品（関数やメソッドなど）が正しく動作するかどうかを確認するテストです。

---

### 3. 注意点やよくあるミス

*   **ブランチ設定の確認**: 現在のワークフローは`work_1005_1050`ブランチにのみ反応します。プロジェクトのメインブランチ（例: `main`や`develop`）や、プルリクエスト時にも実行したい場合は、`on:`セクションを適切に修正する必要があります。
    ```yaml
    on:
      push:
        branches:
          - main # メインブランチへのプッシュ時
          - develop # 開発ブランチへのプッシュ時
      pull_request:
        branches:
          - main # メインブランチへのプルリクエスト時
    ```
*   **`continue-on-error: true` の使い方**: `Run Lint`ステップでは`continue-on-error: true`を設定していますが、これはLintエラーがビルドを停止させないようにするためです。しかし、`Run tests`ステップではこの設定は**ありません**。これは、テストが失敗した場合は、そのジョブ（ひいてはワークフロー全体）を失敗させるべきだからです。テストの失敗は、コードにバグがあることを意味するため、開発者に修正を促す必要があります。
*   **`permissions` の設定**: `permissions`はセキュリティ上非常に重要です。必要最小限の権限を与える「最小権限の原則」に従うべきです。このワークフローでは`contents: read`のみを設定しており、これは良いプラクティスです。もし、ワークフロー内でリポジトリへの書き込み（例: タグの作成、成果物のアップロード）が必要になった場合は、その都度必要な権限を追加してください。
*   **キャッシュの有効性**: `poetry.lock`ファイルが正しく管理されていることが、キャッシュが効果的に機能するための前提です。依存関係を追加・削除した際は、必ず`poetry.lock`を更新し、コミットするようにしましょう。
*   **ジョブの独立性**: `build`ジョブと`test`ジョブはそれぞれ独立した環境で実行されます。そのため、`test`ジョブでも`build`ジョブと同じようにPythonやPoetry、依存関係のインストールを再度行う必要があります。これはGitHub Actionsの設計によるもので、各ジョブがクリーンな状態で実行されることを保証します。

---

【GitHub Dependabot security updatesの設定方法と意義】
GitHubのDependabot security updatesは、あなたのプロジェクトをセキュリティの脅威から守るための強力な自動化ツールです。

### Dependabot security updatesとは？

Dependabotは、あなたのソフトウェアプロジェクトが利用しているライブラリやフレームワーク（依存関係）に、既知のセキュリティ上の弱点（**脆弱性**）がないかを常にチェックしてくれるGitHubの機能です。

その中でも「**Dependabot security updates**」は、もし脆弱性が見つかった場合、その問題を解決できる新しいバージョンのライブラリに更新するための「Pull Request（PR）」を**自動で作成**してくれる機能です。

### なぜ重要なのか？（意義）

この機能が重要な理由は以下の通りです。

1.  **セキュリティリスクの自動低減**: 脆弱性のあるライブラリを使い続けると、悪意のある攻撃者にシステムを乗っ取られたり、情報が漏洩したりするリスクがあります。Dependabot security updatesは、このようなリスクを自動的に検知し、修正を促すことで、プロジェクトの安全性を高めます。
2.  **開発者の負担軽減**: 脆弱性の発見や修正は専門知識が必要で、手動で行うと非常に手間がかかります。この機能を使えば、Dependabotが自動で修正案を提示してくれるため、開発者はセキュリティ対応に時間を取られることなく、本来の機能開発に集中できます。
3.  **常に最新かつ安全な状態を維持**: 自動でセキュリティアップデートのPRが作成されることで、プロジェクトの依存関係を常に最新かつ安全な状態に保ちやすくなります。

### 設定方法

Dependabot security updatesを有効にするのは非常に簡単です。

1.  GitHubで、設定したい**リポジトリのページ**にアクセスします。
2.  上部にある「**Settings**」タブをクリックします。
3.  左側のメニューから「**Code security and analysis**」を選択します。
4.  「Dependabot」セクションにある「**Dependabot security updates**」の項目を見つけます。
5.  その横にある「**Enable**」ボタンをクリックするだけです。

これで、あなたのリポジトリで脆弱性のある依存関係が検出された場合、Dependabotが自動的に修正用のPull Requestを作成してくれるようになります。

**補足**: Dependabotには、脆弱性がない場合でも依存関係を最新バージョンに保つ「Dependabot version updates」という機能もあります。こちらは`.github/dependabot.yml`ファイルを作成して設定しますが、security updatesはGitHubのUIから簡単に有効化できます。

Dependabot security updatesを活用して、あなたのプロジェクトをより安全に保ちましょう。